### PR TITLE
[auto] Translate CPP API Reference to Arabic

### DIFF
--- a/arabic/cpp/_index.md
+++ b/arabic/cpp/_index.md
@@ -1,0 +1,15 @@
+---
+title: "Aspose.OMR لـ C++"
+type: docs
+weight: 10
+url: /ar/cpp/
+keywords: "Aspose.OMR for C++, Aspose OMR, Aspose API Reference."
+description: "Aspose.OMR لـ C++ هو API للتعرف على العلامات الضوئية من صور الأوراق المرقمنة بتقنية OMR."
+is_root: true
+---
+## مساحات الأسماء
+
+| مساحة الاسم | الوصف |
+| --- | --- |
+
+<!-- لا تقم بالتعديل: تم الإنشاء بواسطة xmldocmd لـ Aspose.OMR.dll -->

--- a/arabic/cpp/aspose.omr.cpp/_index.md
+++ b/arabic/cpp/aspose.omr.cpp/_index.md
@@ -1,0 +1,18 @@
+---
+title: "Aspose.OMR"
+second_title: "مرجع API لـ Aspose.OMR لـ C++"
+description: "تحتوي Aspose.OMR على طرق الترخيص."
+type: docs
+weight: 10
+url: /ar/cpp/aspose.omr/
+---
+تحتوي **Aspose.OMR** على طرق الترخيص.
+
+## الفئات
+
+| الفئة | الوصف |
+| --- | --- |
+| [License](./license) | يوفر طرقًا لترخيص المكوّن. |
+| [Metered](./metered) | يوفر طرقًا لتعيين المفتاح القائم على القياس. |
+
+<!-- لا تقم بالتعديل: تم الإنشاء بواسطة xmldocmd لـ Aspose.OMR.dll -->

--- a/arabic/cpp/aspose.omr.cpp/license/_index.md
+++ b/arabic/cpp/aspose.omr.cpp/license/_index.md
@@ -1,0 +1,58 @@
+---
+title: "رخصة"
+second_title: "مرجع API لـ Aspose.OMR لـ .NET"
+description: "يوفر طرقًا لترخيص المكوّن."
+type: docs
+weight: 20
+url: /ar/net/aspose.omr/license/
+---
+## License class
+
+يوفر طرقًا لترخيص المكوّن.
+
+```csharp
+public class License
+```
+
+## المنشئات
+
+| الاسم | الوصف |
+| --- | --- |
+| [License](license)() | يُنشئ نسخة جديدة من هذه الفئة. |
+
+## الخصائص
+
+| الاسم | الوصف |
+| --- | --- |
+| [Embedded](../../aspose.omr/license/embedded) { get; set; } | تم إضافة رقم الرخصة كمورد مضمّن. |
+
+## الطرق
+
+| الاسم | الوصف |
+| --- | --- |
+| [SetLicense](../../aspose.omr/license/setlicense#setlicense)(Stream) | يرخص المكوّن. |
+| [SetLicense](../../aspose.omr/license/setlicense#setlicense_1)(string) | يرخص المكوّن. |
+
+### الأمثلة
+
+في هذا المثال، سيتم محاولة العثور على ملف رخصة يُدعى MyLicense.lic في المجلد الذي يحتوي على المكوّن، وفي المجلد الذي يحتوي على التجميع المستدعي، في مجلد التجميع الرئيسي، ثم في الموارد المضمّنة للتجميع المستدعي.
+
+```csharp
+[C#]
+
+License license = new License();
+license.SetLicense("MyLicense.lic");
+
+
+[Visual Basic]
+
+Dim license As license = New license
+License.SetLicense("MyLicense.lic")
+```
+
+### انظر أيضًا
+
+* namespace [Aspose.OMR](../../aspose.omr)
+* assembly [Aspose.OMR](../../)
+
+<!-- لا تقم بالتعديل: تم الإنشاء بواسطة xmldocmd لـ Aspose.OMR.dll -->

--- a/arabic/cpp/aspose.omr.cpp/license/embedded/_index.md
+++ b/arabic/cpp/aspose.omr.cpp/license/embedded/_index.md
@@ -1,0 +1,23 @@
+---
+title: "مضمن"
+second_title: "مرجع API لـ Aspose.OMR لـ .NET"
+description: "تم إضافة رقم الرخصة كمورد مضمّن."
+type: docs
+weight: 20
+url: /ar/net/aspose.omr/license/embedded/
+---
+## License.Embedded property
+
+تم إضافة رقم الرخصة كمورد مضمّن.
+
+```csharp
+public bool Embedded { get; set; }
+```
+
+### انظر أيضًا
+
+* class [License](../../license)
+* namespace [Aspose.OMR](../../license)
+* assembly [Aspose.OMR](../../../)
+
+<!-- لا تقم بالتعديل: تم الإنشاء بواسطة xmldocmd لـ Aspose.OMR.dll -->

--- a/arabic/cpp/aspose.omr.cpp/license/license/_index.md
+++ b/arabic/cpp/aspose.omr.cpp/license/license/_index.md
@@ -1,0 +1,40 @@
+---
+title: "رخصة"
+second_title: "مرجع API لـ Aspose.OMR لـ .NET"
+description: "يُنشئ نسخة جديدة من هذه الفئة."
+type: docs
+weight: 10
+url: /ar/net/aspose.omr/license/license/
+---
+## License constructor
+
+يُنشئ نسخة جديدة من هذه الفئة.
+
+```csharp
+public License()
+```
+
+### الأمثلة
+
+في هذا المثال، سيتم محاولة العثور على ملف رخصة يُدعى MyLicense.lic في المجلد الذي يحتوي على المكوّن، وفي المجلد الذي يحتوي على التجميع المستدعي، في مجلد التجميع الرئيسي، ثم في الموارد المضمّنة للتجميع المستدعي.
+
+```csharp
+[C#]
+
+License license = new License();
+license.SetLicense("MyLicense.lic");
+
+
+[Visual Basic]
+
+Dim license As license = New license
+License.SetLicense("MyLicense.lic")
+```
+
+### انظر أيضًا
+
+* class [License](../../license)
+* namespace [Aspose.OMR](../../license)
+* assembly [Aspose.OMR](../../../)
+
+<!-- لا تقم بالتعديل: تم الإنشاء بواسطة xmldocmd لـ Aspose.OMR.dll -->

--- a/arabic/cpp/aspose.omr.cpp/license/setlicense/_index.md
+++ b/arabic/cpp/aspose.omr.cpp/license/setlicense/_index.md
@@ -1,0 +1,101 @@
+---
+title: "SetLicense"
+second_title: "مرجع API لـ Aspose.OMR لـ .NET"
+description: "يرخص المكوّن."
+type: docs
+weight: 30
+url: /ar/net/aspose.omr/license/setlicense/
+---
+## SetLicense(string) {#setlicense_1}
+
+يرخص المكوّن.
+
+```csharp
+public void SetLicense(string licenseName)
+```
+
+### ملاحظات
+
+يحاول العثور على الرخصة في المواقع التالية:
+
+1. مسار صريح.
+
+2. المجلد الذي يحتوي على تجميع مكوّن Aspose.
+
+3. المجلد الذي يحتوي على تجميع الاستدعاء الخاص بالعميل.
+
+4. المجلد الذي يحتوي على التجميع (البدء).
+
+5. مورد مضمن في تجميع الاستدعاء للعميل.
+
+**Note:**On the .NET Compact Framework, tries to find the license only in these locations:
+
+1. مسار صريح.
+
+2. مورد مضمن في تجميع الاستدعاء للعميل.
+
+### الأمثلة
+
+في هذا المثال، سيتم محاولة العثور على ملف رخصة يُدعى MyLicense.lic في المجلد الذي يحتوي على المكوّن، وفي المجلد الذي يحتوي على التجميع المستدعي، في مجلد التجميع الرئيسي، ثم في الموارد المضمّنة للتجميع المستدعي.
+
+```csharp
+[C#]
+
+License license = new License();
+license.SetLicense("MyLicense.lic");
+
+
+[Visual Basic]
+
+Dim license As License = New License
+license.SetLicense("MyLicense.lic")
+```
+
+يمكن أن يكون اسم ملف كامل أو قصير أو اسم مورد مضمن. استخدم سلسلة فارغة للتبديل إلى وضع التقييم.
+
+### انظر أيضًا
+
+* class [License](../../license)
+* namespace [Aspose.OMR](../../license)
+* assembly [Aspose.OMR](../../../)
+
+---
+
+## SetLicense(Stream) {#setlicense}
+
+يرخص المكوّن.
+
+```csharp
+public void SetLicense(Stream stream)
+```
+
+| معامل | نوع | الوصف |
+| --- | --- | --- |
+| دفق | دفق | دفق يحتوي على الترخيص. |
+
+### ملاحظات
+
+استخدم هذه الطريقة لتحميل الترخيص من دفق.
+
+### الأمثلة
+
+```csharp
+[C#]
+
+License license = new License();
+license.SetLicense(myStream);
+
+
+[Visual Basic]
+
+Dim license as License = new License
+license.SetLicense(myStream)
+```
+
+### انظر أيضًا
+
+* class [License](../../license)
+* namespace [Aspose.OMR](../../license)
+* assembly [Aspose.OMR](../../../)
+
+<!-- لا تقم بالتعديل: تم الإنشاء بواسطة xmldocmd لـ Aspose.OMR.dll -->

--- a/arabic/cpp/aspose.omr.cpp/metered/_index.md
+++ b/arabic/cpp/aspose.omr.cpp/metered/_index.md
@@ -1,0 +1,60 @@
+---
+title: "قائم على القياس"
+second_title: "مرجع API لـ Aspose.OMR لـ .NET"
+description: "يوفر طرقًا لتعيين المفتاح القائم على القياس."
+type: docs
+weight: 10
+url: /ar/net/aspose.omr/metered/
+---
+## Metered class
+
+يوفر طرقًا لتعيين المفتاح القائم على القياس.
+
+```csharp
+public class Metered
+```
+
+## المنشئات
+
+| الاسم | الوصف |
+| --- | --- |
+| [Metered](metered)() | يُنشئ نسخة جديدة من هذه الفئة. |
+
+## الطرق
+
+| الاسم | الوصف |
+| --- | --- |
+| [SetMeteredKey](../../aspose.omr/metered/setmeteredkey)(string, string) | يضبط المفتاح القائم على القياس العام والخاص |
+| static [GetConsumptionCredit](../../aspose.omr/metered/getconsumptioncredit)() | يحصل على رصيد الاستهلاك |
+| static [GetConsumptionQuantity](../../aspose.omr/metered/getconsumptionquantity)() | يحصل على حجم ملف الاستهلاك |
+
+### الأمثلة
+
+في هذا المثال، سيتم محاولة تعيين المفتاح القائم على القياس العام والخاص
+
+```csharp
+[C#]
+
+Metered matered = new Metered();
+matered.SetMeteredKey("PublicKey", "PrivateKey");
+
+
+[Visual Basic]
+
+Dim matered As Metered = New Metered
+matered.SetMeteredKey("PublicKey", "PrivateKey")
+```
+
+ملف jar الخاص بالمكوّن:
+
+```csharp
+Metered matered = new Metered();
+matered.setMeteredKey("PublicKey", "PrivateKey");
+```
+
+### انظر أيضًا
+
+* namespace [Aspose.OMR](../../aspose.omr)
+* assembly [Aspose.OMR](../../)
+
+<!-- لا تقم بالتعديل: تم الإنشاء بواسطة xmldocmd لـ Aspose.OMR.dll -->

--- a/arabic/cpp/aspose.omr.cpp/metered/getconsumptioncredit/_index.md
+++ b/arabic/cpp/aspose.omr.cpp/metered/getconsumptioncredit/_index.md
@@ -1,0 +1,27 @@
+---
+title: "GetConsumptionCredit"
+second_title: "مرجع API لـ Aspose.OMR لـ .NET"
+description: "يحصل على رصيد الاستهلاك"
+type: docs
+weight: 30
+url: /ar/net/aspose.omr/metered/getconsumptioncredit/
+---
+## Metered.GetConsumptionCredit method
+
+يحصل على رصيد الاستهلاك
+
+```csharp
+public static decimal GetConsumptionCredit()
+```
+
+### قيمة الإرجاع
+
+كمية الاستهلاك
+
+### انظر أيضًا
+
+* class [Metered](../../metered)
+* namespace [Aspose.OMR](../../metered)
+* assembly [Aspose.OMR](../../../)
+
+<!-- لا تقم بالتعديل: تم الإنشاء بواسطة xmldocmd لـ Aspose.OMR.dll -->

--- a/arabic/cpp/aspose.omr.cpp/metered/getconsumptionquantity/_index.md
+++ b/arabic/cpp/aspose.omr.cpp/metered/getconsumptionquantity/_index.md
@@ -1,0 +1,27 @@
+---
+title: "GetConsumptionQuantity"
+second_title: "مرجع API لـ Aspose.OMR لـ .NET"
+description: "يحصل على حجم ملف الاستهلاك"
+type: docs
+weight: 40
+url: /ar/net/aspose.omr/metered/getconsumptionquantity/
+---
+## Metered.GetConsumptionQuantity method
+
+يحصل على حجم ملف الاستهلاك
+
+```csharp
+public static decimal GetConsumptionQuantity()
+```
+
+### قيمة الإرجاع
+
+كمية الاستهلاك
+
+### انظر أيضًا
+
+* class [Metered](../../metered)
+* namespace [Aspose.OMR](../../metered)
+* assembly [Aspose.OMR](../../../)
+
+<!-- لا تقم بالتعديل: تم الإنشاء بواسطة xmldocmd لـ Aspose.OMR.dll -->

--- a/arabic/cpp/aspose.omr.cpp/metered/metered/_index.md
+++ b/arabic/cpp/aspose.omr.cpp/metered/metered/_index.md
@@ -1,0 +1,23 @@
+---
+title: "قائم على القياس"
+second_title: "مرجع API لـ Aspose.OMR لـ .NET"
+description: "يُنشئ نسخة جديدة من هذه الفئة."
+type: docs
+weight: 10
+url: /ar/net/aspose.omr/metered/metered/
+---
+## Metered constructor
+
+يُنشئ نسخة جديدة من هذه الفئة.
+
+```csharp
+public Metered()
+```
+
+### انظر أيضًا
+
+* class [Metered](../../metered)
+* namespace [Aspose.OMR](../../metered)
+* assembly [Aspose.OMR](../../../)
+
+<!-- لا تقم بالتعديل: تم الإنشاء بواسطة xmldocmd لـ Aspose.OMR.dll -->

--- a/arabic/cpp/aspose.omr.cpp/metered/setmeteredkey/_index.md
+++ b/arabic/cpp/aspose.omr.cpp/metered/setmeteredkey/_index.md
@@ -1,0 +1,28 @@
+---
+title: "SetMeteredKey"
+second_title: "مرجع API لـ Aspose.OMR لـ .NET"
+description: "يضبط المفتاح القائم على القياس العام والخاص"
+type: docs
+weight: 20
+url: /ar/net/aspose.omr/metered/setmeteredkey/
+---
+## Metered.SetMeteredKey method
+
+يضبط المفتاح القائم على القياس العام والخاص
+
+```csharp
+public void SetMeteredKey(string publicKey, string privateKey)
+```
+
+| معامل | نوع | الوصف |
+| --- | --- | --- |
+| publicKey | String | المفتاح العام |
+| privateKey | String | المفتاح الخاص |
+
+### انظر أيضًا
+
+* class [Metered](../../metered)
+* namespace [Aspose.OMR](../../metered)
+* assembly [Aspose.OMR](../../../)
+
+<!-- لا تقم بالتعديل: تم الإنشاء بواسطة xmldocmd لـ Aspose.OMR.dll -->


### PR DESCRIPTION
Automated translation of the CPP API Reference to **Arabic** (`ar`) generated by RDA.

- Pages translated: 11/11
- Errors: 0
- Source: `english/cpp`
- Output: `arabic/cpp`

🤖 Generated by RDA