### PR TITLE
[auto] Translate CPP API Reference to French

### DIFF
--- a/french/cpp/_index.md
+++ b/french/cpp/_index.md
@@ -1,0 +1,15 @@
+---
+title: "Aspose.OMR for C++"
+type: docs
+weight: 10
+url: /fr/cpp/
+keywords: "Aspose.OMR for C++, Aspose OMR, Aspose API Reference."
+description: "Aspose.OMR for C++ est une API permettant de reconnaître les marques optiques à partir d'images de feuilles numérisées OMR."
+is_root: true
+---
+## Espaces de noms
+
+| Espace de noms | Description |
+| --- | --- |
+
+<!-- NE PAS MODIFIER : généré par xmldocmd pour Aspose.OMR.dll -->

--- a/french/cpp/aspose.omr.cpp/_index.md
+++ b/french/cpp/aspose.omr.cpp/_index.md
@@ -1,0 +1,18 @@
+---
+title: "Aspose.OMR"
+second_title: "Référence de l'API Aspose.OMR for C++"
+description: "Le Aspose.OMR contient des méthodes de licence."
+type: docs
+weight: 10
+url: /fr/cpp/aspose.omr/
+---
+Le **Aspose.OMR** contient des méthodes de licence.
+
+## Classes
+
+| Classe | Description |
+| --- | --- |
+| [License](./license) | Fournit des méthodes pour licencier le composant. |
+| [Metered](./metered) | Fournit des méthodes pour définir la clé mesurée. |
+
+<!-- NE PAS MODIFIER : généré par xmldocmd pour Aspose.OMR.dll -->

--- a/french/cpp/aspose.omr.cpp/license/_index.md
+++ b/french/cpp/aspose.omr.cpp/license/_index.md
@@ -1,0 +1,58 @@
+---
+title: "Licence"
+second_title: "Référence de l'API Aspose.OMR for .NET"
+description: "Fournit des méthodes pour licencier le composant."
+type: docs
+weight: 20
+url: /fr/net/aspose.omr/license/
+---
+## License class
+
+Fournit des méthodes pour licencier le composant.
+
+```csharp
+public class License
+```
+
+## Constructeurs
+
+| Nom | Description |
+| --- | --- |
+| [License](license)() | Initialise une nouvelle instance de cette classe. |
+
+## Propriétés
+
+| Nom | Description |
+| --- | --- |
+| [Embedded](../../aspose.omr/license/embedded) { get; set; } | Le numéro de licence a été ajouté en tant que ressource intégrée. |
+
+## Méthodes
+
+| Nom | Description |
+| --- | --- |
+| [SetLicense](../../aspose.omr/license/setlicense#setlicense)(Stream) | Licence le composant. |
+| [SetLicense](../../aspose.omr/license/setlicense#setlicense_1)(string) | Licence le composant. |
+
+### Exemples
+
+Dans cet exemple, une tentative sera faite pour trouver un fichier de licence nommé MyLicense.lic dans le dossier contenant le composant, dans le dossier contenant l'assembly appelant, dans le dossier de l'assembly d'entrée, puis dans les ressources intégrées de l'assembly appelant.
+
+```csharp
+[C#]
+
+License license = new License();
+license.SetLicense("MyLicense.lic");
+
+
+[Visual Basic]
+
+Dim license As license = New license
+License.SetLicense("MyLicense.lic")
+```
+
+### Voir aussi
+
+* namespace [Aspose.OMR](../../aspose.omr)
+* assembly [Aspose.OMR](../../)
+
+<!-- NE PAS MODIFIER : généré par xmldocmd pour Aspose.OMR.dll -->

--- a/french/cpp/aspose.omr.cpp/license/embedded/_index.md
+++ b/french/cpp/aspose.omr.cpp/license/embedded/_index.md
@@ -1,0 +1,23 @@
+---
+title: "Intégré"
+second_title: "Référence de l'API Aspose.OMR for .NET"
+description: "Le numéro de licence a été ajouté en tant que ressource intégrée."
+type: docs
+weight: 20
+url: /fr/net/aspose.omr/license/embedded/
+---
+## License.Embedded property
+
+Le numéro de licence a été ajouté en tant que ressource intégrée.
+
+```csharp
+public bool Embedded { get; set; }
+```
+
+### Voir aussi
+
+* class [License](../../license)
+* namespace [Aspose.OMR](../../license)
+* assembly [Aspose.OMR](../../../)
+
+<!-- NE PAS MODIFIER : généré par xmldocmd pour Aspose.OMR.dll -->

--- a/french/cpp/aspose.omr.cpp/license/license/_index.md
+++ b/french/cpp/aspose.omr.cpp/license/license/_index.md
@@ -1,0 +1,40 @@
+---
+title: "Licence"
+second_title: "Référence de l'API Aspose.OMR for .NET"
+description: "Initialise une nouvelle instance de cette classe."
+type: docs
+weight: 10
+url: /fr/net/aspose.omr/license/license/
+---
+## License constructor
+
+Initialise une nouvelle instance de cette classe.
+
+```csharp
+public License()
+```
+
+### Exemples
+
+Dans cet exemple, une tentative sera faite pour trouver un fichier de licence nommé MyLicense.lic dans le dossier contenant le composant, dans le dossier contenant l'assembly appelant, dans le dossier de l'assembly d'entrée, puis dans les ressources intégrées de l'assembly appelant.
+
+```csharp
+[C#]
+
+License license = new License();
+license.SetLicense("MyLicense.lic");
+
+
+[Visual Basic]
+
+Dim license As license = New license
+License.SetLicense("MyLicense.lic")
+```
+
+### Voir aussi
+
+* class [License](../../license)
+* namespace [Aspose.OMR](../../license)
+* assembly [Aspose.OMR](../../../)
+
+<!-- NE PAS MODIFIER : généré par xmldocmd pour Aspose.OMR.dll -->

--- a/french/cpp/aspose.omr.cpp/license/setlicense/_index.md
+++ b/french/cpp/aspose.omr.cpp/license/setlicense/_index.md
@@ -1,0 +1,101 @@
+---
+title: "SetLicense"
+second_title: "Référence de l'API Aspose.OMR for .NET"
+description: "Licence le composant."
+type: docs
+weight: 30
+url: /fr/net/aspose.omr/license/setlicense/
+---
+## SetLicense(string) {#setlicense_1}
+
+Licence le composant.
+
+```csharp
+public void SetLicense(string licenseName)
+```
+
+### Remarques
+
+Tente de trouver la licence aux emplacements suivants :
+
+1. Chemin explicite.
+
+2. Le dossier contenant l'assembly du composant Aspose.
+
+3. Le dossier contenant l'assembly appelant du client.
+
+4. Le dossier qui contient l'assembly d'entrée (démarrage).
+
+5. Une ressource intégrée dans l'assembly appelant du client.
+
+**Note:**On the .NET Compact Framework, tries to find the license only in these locations:
+
+1. Chemin explicite.
+
+2. Une ressource intégrée dans l'assembly appelant du client.
+
+### Exemples
+
+Dans cet exemple, une tentative sera faite pour trouver un fichier de licence nommé MyLicense.lic dans le dossier contenant le composant, dans le dossier contenant l'assembly appelant, dans le dossier de l'assembly d'entrée, puis dans les ressources intégrées de l'assembly appelant.
+
+```csharp
+[C#]
+
+License license = new License();
+license.SetLicense("MyLicense.lic");
+
+
+[Visual Basic]
+
+Dim license As License = New License
+license.SetLicense("MyLicense.lic")
+```
+
+Peut être un nom de fichier complet ou court ou le nom d'une ressource intégrée. Utilisez une chaîne vide pour passer en mode d'évaluation.
+
+### Voir aussi
+
+* class [License](../../license)
+* namespace [Aspose.OMR](../../license)
+* assembly [Aspose.OMR](../../../)
+
+---
+
+## SetLicense(Stream) {#setlicense}
+
+Licence le composant.
+
+```csharp
+public void SetLicense(Stream stream)
+```
+
+| Paramètre | Type | Description |
+| --- | --- | --- |
+| flux | Flux | Un flux qui contient la licence. |
+
+### Remarques
+
+Utilisez cette méthode pour charger une licence à partir d'un flux.
+
+### Exemples
+
+```csharp
+[C#]
+
+License license = new License();
+license.SetLicense(myStream);
+
+
+[Visual Basic]
+
+Dim license as License = new License
+license.SetLicense(myStream)
+```
+
+### Voir aussi
+
+* class [License](../../license)
+* namespace [Aspose.OMR](../../license)
+* assembly [Aspose.OMR](../../../)
+
+<!-- NE PAS MODIFIER : généré par xmldocmd pour Aspose.OMR.dll -->

--- a/french/cpp/aspose.omr.cpp/metered/_index.md
+++ b/french/cpp/aspose.omr.cpp/metered/_index.md
@@ -1,0 +1,60 @@
+---
+title: "Mesuré"
+second_title: "Référence de l'API Aspose.OMR for .NET"
+description: "Fournit des méthodes pour définir la clé mesurée."
+type: docs
+weight: 10
+url: /fr/net/aspose.omr/metered/
+---
+## Metered class
+
+Fournit des méthodes pour définir la clé mesurée.
+
+```csharp
+public class Metered
+```
+
+## Constructeurs
+
+| Nom | Description |
+| --- | --- |
+| [Metered](metered)() | Initialise une nouvelle instance de cette classe. |
+
+## Méthodes
+
+| Nom | Description |
+| --- | --- |
+| [SetMeteredKey](../../aspose.omr/metered/setmeteredkey)(string, string) | Définit la clé publique et privée mesurée |
+| static [GetConsumptionCredit](../../aspose.omr/metered/getconsumptioncredit)() | Obtient le crédit de consommation |
+| static [GetConsumptionQuantity](../../aspose.omr/metered/getconsumptionquantity)() | Obtient la taille du fichier de consommation |
+
+### Exemples
+
+Dans cet exemple, une tentative sera faite pour définir la clé publique et privée mesurée
+
+```csharp
+[C#]
+
+Metered matered = new Metered();
+matered.SetMeteredKey("PublicKey", "PrivateKey");
+
+
+[Visual Basic]
+
+Dim matered As Metered = New Metered
+matered.SetMeteredKey("PublicKey", "PrivateKey")
+```
+
+le fichier jar du composant:
+
+```csharp
+Metered matered = new Metered();
+matered.setMeteredKey("PublicKey", "PrivateKey");
+```
+
+### Voir aussi
+
+* namespace [Aspose.OMR](../../aspose.omr)
+* assembly [Aspose.OMR](../../)
+
+<!-- NE PAS MODIFIER : généré par xmldocmd pour Aspose.OMR.dll -->

--- a/french/cpp/aspose.omr.cpp/metered/getconsumptioncredit/_index.md
+++ b/french/cpp/aspose.omr.cpp/metered/getconsumptioncredit/_index.md
@@ -1,0 +1,27 @@
+---
+title: "GetConsumptionCredit"
+second_title: "Référence de l'API Aspose.OMR for .NET"
+description: "Obtient le crédit de consommation"
+type: docs
+weight: 30
+url: /fr/net/aspose.omr/metered/getconsumptioncredit/
+---
+## Metered.GetConsumptionCredit method
+
+Obtient le crédit de consommation
+
+```csharp
+public static decimal GetConsumptionCredit()
+```
+
+### Valeur de retour
+
+quantité de consommation
+
+### Voir aussi
+
+* class [Metered](../../metered)
+* namespace [Aspose.OMR](../../metered)
+* assembly [Aspose.OMR](../../../)
+
+<!-- NE PAS MODIFIER : généré par xmldocmd pour Aspose.OMR.dll -->

--- a/french/cpp/aspose.omr.cpp/metered/getconsumptionquantity/_index.md
+++ b/french/cpp/aspose.omr.cpp/metered/getconsumptionquantity/_index.md
@@ -1,0 +1,27 @@
+---
+title: "GetConsumptionQuantity"
+second_title: "Référence de l'API Aspose.OMR for .NET"
+description: "Obtient la taille du fichier de consommation"
+type: docs
+weight: 40
+url: /fr/net/aspose.omr/metered/getconsumptionquantity/
+---
+## Metered.GetConsumptionQuantity method
+
+Obtient la taille du fichier de consommation
+
+```csharp
+public static decimal GetConsumptionQuantity()
+```
+
+### Valeur de retour
+
+quantité de consommation
+
+### Voir aussi
+
+* class [Metered](../../metered)
+* namespace [Aspose.OMR](../../metered)
+* assembly [Aspose.OMR](../../../)
+
+<!-- NE PAS MODIFIER : généré par xmldocmd pour Aspose.OMR.dll -->

--- a/french/cpp/aspose.omr.cpp/metered/metered/_index.md
+++ b/french/cpp/aspose.omr.cpp/metered/metered/_index.md
@@ -1,0 +1,23 @@
+---
+title: "Mesuré"
+second_title: "Référence de l'API Aspose.OMR for .NET"
+description: "Initialise une nouvelle instance de cette classe."
+type: docs
+weight: 10
+url: /fr/net/aspose.omr/metered/metered/
+---
+## Metered constructor
+
+Initialise une nouvelle instance de cette classe.
+
+```csharp
+public Metered()
+```
+
+### Voir aussi
+
+* class [Metered](../../metered)
+* namespace [Aspose.OMR](../../metered)
+* assembly [Aspose.OMR](../../../)
+
+<!-- NE PAS MODIFIER : généré par xmldocmd pour Aspose.OMR.dll -->

--- a/french/cpp/aspose.omr.cpp/metered/setmeteredkey/_index.md
+++ b/french/cpp/aspose.omr.cpp/metered/setmeteredkey/_index.md
@@ -1,0 +1,28 @@
+---
+title: "SetMeteredKey"
+second_title: "Référence de l'API Aspose.OMR for .NET"
+description: "Définit la clé publique et privée mesurée"
+type: docs
+weight: 20
+url: /fr/net/aspose.omr/metered/setmeteredkey/
+---
+## Metered.SetMeteredKey method
+
+Définit la clé publique et privée mesurée
+
+```csharp
+public void SetMeteredKey(string publicKey, string privateKey)
+```
+
+| Paramètre | Type | Description |
+| --- | --- | --- |
+| publicKey | String | clé publique |
+| privateKey | String | clé privée |
+
+### Voir aussi
+
+* class [Metered](../../metered)
+* namespace [Aspose.OMR](../../metered)
+* assembly [Aspose.OMR](../../../)
+
+<!-- NE PAS MODIFIER : généré par xmldocmd pour Aspose.OMR.dll -->


### PR DESCRIPTION
Automated translation of the CPP API Reference to **French** (`fr`) generated by RDA.

- Pages translated: 11/11
- Errors: 0
- Source: `english/cpp`
- Output: `french/cpp`

🤖 Generated by RDA