### PR TITLE
[auto] Translate CPP API Reference to German

### DIFF
--- a/german/cpp/_index.md
+++ b/german/cpp/_index.md
@@ -1,0 +1,15 @@
+---
+title: "Aspose.OMR für C++"
+type: docs
+weight: 10
+url: /de/cpp/
+keywords: "Aspose.OMR for C++, Aspose OMR, Aspose API Reference."
+description: "Aspose.OMR für C++ ist eine API, um optische Markierungen aus digitalisierten OMR-Blattbildern zu erkennen."
+is_root: true
+---
+## Namensräume
+
+| Namensraum | Beschreibung |
+| --- | --- |
+
+<!-- NICHT BEARBEITEN: generiert von xmldocmd für Aspose.OMR.dll -->

--- a/german/cpp/aspose.omr.cpp/_index.md
+++ b/german/cpp/aspose.omr.cpp/_index.md
@@ -1,0 +1,18 @@
+---
+title: "Aspose.OMR"
+second_title: "Aspose.OMR für C++ API-Referenz"
+description: "Das Aspose.OMR enthält Lizenzierungsmethoden."
+type: docs
+weight: 10
+url: /de/cpp/aspose.omr/
+---
+Das **Aspose.OMR** enthält Lizenzierungsmethoden.
+
+## Klassen
+
+| Klasse | Beschreibung |
+| --- | --- |
+| [License](./license) | Stellt Methoden zur Lizenzierung der Komponente bereit. |
+| [Metered](./metered) | Stellt Methoden zum Festlegen des Metered-Schlüssels bereit. |
+
+<!-- NICHT BEARBEITEN: generiert von xmldocmd für Aspose.OMR.dll -->

--- a/german/cpp/aspose.omr.cpp/license/_index.md
+++ b/german/cpp/aspose.omr.cpp/license/_index.md
@@ -1,0 +1,58 @@
+---
+title: "Lizenz"
+second_title: "Aspose.OMR für .NET API-Referenz"
+description: "Stellt Methoden zur Lizenzierung der Komponente bereit."
+type: docs
+weight: 20
+url: /de/net/aspose.omr/license/
+---
+## License class
+
+Stellt Methoden zur Lizenzierung der Komponente bereit.
+
+```csharp
+public class License
+```
+
+## Konstruktoren
+
+| Name | Beschreibung |
+| --- | --- |
+| [License](license)() | Initialisiert eine neue Instanz dieser Klasse. |
+
+## Eigenschaften
+
+| Name | Beschreibung |
+| --- | --- |
+| [Embedded](../../aspose.omr/license/embedded) { get; set; } | Lizenznummer wurde als eingebettete Ressource hinzugefügt. |
+
+## Methoden
+
+| Name | Beschreibung |
+| --- | --- |
+| [SetLicense](../../aspose.omr/license/setlicense#setlicense)(Stream) | Lizenziert die Komponente. |
+| [SetLicense](../../aspose.omr/license/setlicense#setlicense_1)(string) | Lizenziert die Komponente. |
+
+### Beispiele
+
+In diesem Beispiel wird versucht, eine Lizenzdatei mit dem Namen MyLicense.lic im Ordner zu finden, der die Komponente enthält, im Ordner, der die aufrufende Assembly enthält, im Ordner der Einstieg‑Assembly und anschließend in den eingebetteten Ressourcen der aufrufenden Assembly.
+
+```csharp
+[C#]
+
+License license = new License();
+license.SetLicense("MyLicense.lic");
+
+
+[Visual Basic]
+
+Dim license As license = New license
+License.SetLicense("MyLicense.lic")
+```
+
+### Siehe auch
+
+* namespace [Aspose.OMR](../../aspose.omr)
+* assembly [Aspose.OMR](../../)
+
+<!-- NICHT BEARBEITEN: generiert von xmldocmd für Aspose.OMR.dll -->

--- a/german/cpp/aspose.omr.cpp/license/embedded/_index.md
+++ b/german/cpp/aspose.omr.cpp/license/embedded/_index.md
@@ -1,0 +1,23 @@
+---
+title: "Eingebettet"
+second_title: "Aspose.OMR für .NET API-Referenz"
+description: "Lizenznummer wurde als eingebettete Ressource hinzugefügt."
+type: docs
+weight: 20
+url: /de/net/aspose.omr/license/embedded/
+---
+## License.Embedded property
+
+Lizenznummer wurde als eingebettete Ressource hinzugefügt.
+
+```csharp
+public bool Embedded { get; set; }
+```
+
+### Siehe auch
+
+* class [License](../../license)
+* namespace [Aspose.OMR](../../license)
+* assembly [Aspose.OMR](../../../)
+
+<!-- NICHT BEARBEITEN: generiert von xmldocmd für Aspose.OMR.dll -->

--- a/german/cpp/aspose.omr.cpp/license/license/_index.md
+++ b/german/cpp/aspose.omr.cpp/license/license/_index.md
@@ -1,0 +1,40 @@
+---
+title: "Lizenz"
+second_title: "Aspose.OMR für .NET API-Referenz"
+description: "Initialisiert eine neue Instanz dieser Klasse."
+type: docs
+weight: 10
+url: /de/net/aspose.omr/license/license/
+---
+## License constructor
+
+Initialisiert eine neue Instanz dieser Klasse.
+
+```csharp
+public License()
+```
+
+### Beispiele
+
+In diesem Beispiel wird versucht, eine Lizenzdatei mit dem Namen MyLicense.lic im Ordner zu finden, der die Komponente enthält, im Ordner, der die aufrufende Assembly enthält, im Ordner der Einstieg‑Assembly und anschließend in den eingebetteten Ressourcen der aufrufenden Assembly.
+
+```csharp
+[C#]
+
+License license = new License();
+license.SetLicense("MyLicense.lic");
+
+
+[Visual Basic]
+
+Dim license As license = New license
+License.SetLicense("MyLicense.lic")
+```
+
+### Siehe auch
+
+* class [License](../../license)
+* namespace [Aspose.OMR](../../license)
+* assembly [Aspose.OMR](../../../)
+
+<!-- NICHT BEARBEITEN: generiert von xmldocmd für Aspose.OMR.dll -->

--- a/german/cpp/aspose.omr.cpp/license/setlicense/_index.md
+++ b/german/cpp/aspose.omr.cpp/license/setlicense/_index.md
@@ -1,0 +1,101 @@
+---
+title: "SetLicense"
+second_title: "Aspose.OMR für .NET API-Referenz"
+description: "Lizenziert die Komponente."
+type: docs
+weight: 30
+url: /de/net/aspose.omr/license/setlicense/
+---
+## SetLicense(string) {#setlicense_1}
+
+Lizenziert die Komponente.
+
+```csharp
+public void SetLicense(string licenseName)
+```
+
+### Bemerkungen
+
+Versucht, die Lizenz an den folgenden Orten zu finden:
+
+1. Expliziter Pfad.
+
+2. Der Ordner, der die Aspose‑Komponenten‑Assembly enthält.
+
+3. Der Ordner, der die aufrufende Assembly des Clients enthält.
+
+4. Der Ordner, der die Einstieg (Startup) Assembly enthält.
+
+5. Eine eingebettete Ressource in der aufrufenden Assembly des Clients.
+
+**Note:**On the .NET Compact Framework, tries to find the license only in these locations:
+
+1. Expliziter Pfad.
+
+2. Eine eingebettete Ressource in der aufrufenden Assembly des Clients.
+
+### Beispiele
+
+In diesem Beispiel wird versucht, eine Lizenzdatei mit dem Namen MyLicense.lic im Ordner zu finden, der die Komponente enthält, im Ordner, der die aufrufende Assembly enthält, im Ordner der Einstieg‑Assembly und anschließend in den eingebetteten Ressourcen der aufrufenden Assembly.
+
+```csharp
+[C#]
+
+License license = new License();
+license.SetLicense("MyLicense.lic");
+
+
+[Visual Basic]
+
+Dim license As License = New License
+license.SetLicense("MyLicense.lic")
+```
+
+Kann ein voller oder kurzer Dateiname oder der Name einer eingebetteten Ressource sein. Verwenden Sie eine leere Zeichenkette, um in den Evaluierungsmodus zu wechseln.
+
+### Siehe auch
+
+* class [License](../../license)
+* namespace [Aspose.OMR](../../license)
+* assembly [Aspose.OMR](../../../)
+
+---
+
+## SetLicense(Stream) {#setlicense}
+
+Lizenziert die Komponente.
+
+```csharp
+public void SetLicense(Stream stream)
+```
+
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| stream | Stream | Ein Stream, der die Lizenz enthält. |
+
+### Bemerkungen
+
+Verwenden Sie diese Methode, um eine Lizenz aus einem Stream zu laden.
+
+### Beispiele
+
+```csharp
+[C#]
+
+License license = new License();
+license.SetLicense(myStream);
+
+
+[Visual Basic]
+
+Dim license as License = new License
+license.SetLicense(myStream)
+```
+
+### Siehe auch
+
+* class [License](../../license)
+* namespace [Aspose.OMR](../../license)
+* assembly [Aspose.OMR](../../../)
+
+<!-- NICHT BEARBEITEN: generiert von xmldocmd für Aspose.OMR.dll -->

--- a/german/cpp/aspose.omr.cpp/metered/_index.md
+++ b/german/cpp/aspose.omr.cpp/metered/_index.md
@@ -1,0 +1,60 @@
+---
+title: "Gemessen"
+second_title: "Aspose.OMR für .NET API-Referenz"
+description: "Stellt Methoden zum Festlegen des Metered-Schlüssels bereit."
+type: docs
+weight: 10
+url: /de/net/aspose.omr/metered/
+---
+## Metered class
+
+Stellt Methoden zum Festlegen des Metered-Schlüssels bereit.
+
+```csharp
+public class Metered
+```
+
+## Konstruktoren
+
+| Name | Beschreibung |
+| --- | --- |
+| [Metered](metered)() | Initialisiert eine neue Instanz dieser Klasse. |
+
+## Methoden
+
+| Name | Beschreibung |
+| --- | --- |
+| [SetMeteredKey](../../aspose.omr/metered/setmeteredkey)(string, string) | Setzt den Metered-öffentlichen und privaten Schlüssel |
+| static [GetConsumptionCredit](../../aspose.omr/metered/getconsumptioncredit)() | Ermittelt das Verbrauchsguthaben |
+| static [GetConsumptionQuantity](../../aspose.omr/metered/getconsumptionquantity)() | Ermittelt die Verbrauchsdateigröße |
+
+### Beispiele
+
+In diesem Beispiel wird versucht, den Metered-öffentlichen und privaten Schlüssel festzulegen.
+
+```csharp
+[C#]
+
+Metered matered = new Metered();
+matered.SetMeteredKey("PublicKey", "PrivateKey");
+
+
+[Visual Basic]
+
+Dim matered As Metered = New Metered
+matered.SetMeteredKey("PublicKey", "PrivateKey")
+```
+
+die Komponenten‑Jar‑Datei:
+
+```csharp
+Metered matered = new Metered();
+matered.setMeteredKey("PublicKey", "PrivateKey");
+```
+
+### Siehe auch
+
+* namespace [Aspose.OMR](../../aspose.omr)
+* assembly [Aspose.OMR](../../)
+
+<!-- NICHT BEARBEITEN: generiert von xmldocmd für Aspose.OMR.dll -->

--- a/german/cpp/aspose.omr.cpp/metered/getconsumptioncredit/_index.md
+++ b/german/cpp/aspose.omr.cpp/metered/getconsumptioncredit/_index.md
@@ -1,0 +1,27 @@
+---
+title: "GetConsumptionCredit"
+second_title: "Aspose.OMR für .NET API-Referenz"
+description: "Ermittelt das Verbrauchsguthaben"
+type: docs
+weight: 30
+url: /de/net/aspose.omr/metered/getconsumptioncredit/
+---
+## Metered.GetConsumptionCredit method
+
+Ermittelt das Verbrauchsguthaben
+
+```csharp
+public static decimal GetConsumptionCredit()
+```
+
+### Rückgabewert
+
+Verbrauchsmenge
+
+### Siehe auch
+
+* class [Metered](../../metered)
+* namespace [Aspose.OMR](../../metered)
+* assembly [Aspose.OMR](../../../)
+
+<!-- NICHT BEARBEITEN: generiert von xmldocmd für Aspose.OMR.dll -->

--- a/german/cpp/aspose.omr.cpp/metered/getconsumptionquantity/_index.md
+++ b/german/cpp/aspose.omr.cpp/metered/getconsumptionquantity/_index.md
@@ -1,0 +1,27 @@
+---
+title: "GetConsumptionQuantity"
+second_title: "Aspose.OMR für .NET API-Referenz"
+description: "Ermittelt die Verbrauchsdateigröße"
+type: docs
+weight: 40
+url: /de/net/aspose.omr/metered/getconsumptionquantity/
+---
+## Metered.GetConsumptionQuantity method
+
+Ermittelt die Verbrauchsdateigröße
+
+```csharp
+public static decimal GetConsumptionQuantity()
+```
+
+### Rückgabewert
+
+Verbrauchsmenge
+
+### Siehe auch
+
+* class [Metered](../../metered)
+* namespace [Aspose.OMR](../../metered)
+* assembly [Aspose.OMR](../../../)
+
+<!-- NICHT BEARBEITEN: generiert von xmldocmd für Aspose.OMR.dll -->

--- a/german/cpp/aspose.omr.cpp/metered/metered/_index.md
+++ b/german/cpp/aspose.omr.cpp/metered/metered/_index.md
@@ -1,0 +1,23 @@
+---
+title: "Gemessen"
+second_title: "Aspose.OMR für .NET API-Referenz"
+description: "Initialisiert eine neue Instanz dieser Klasse."
+type: docs
+weight: 10
+url: /de/net/aspose.omr/metered/metered/
+---
+## Metered constructor
+
+Initialisiert eine neue Instanz dieser Klasse.
+
+```csharp
+public Metered()
+```
+
+### Siehe auch
+
+* class [Metered](../../metered)
+* namespace [Aspose.OMR](../../metered)
+* assembly [Aspose.OMR](../../../)
+
+<!-- NICHT BEARBEITEN: generiert von xmldocmd für Aspose.OMR.dll -->

--- a/german/cpp/aspose.omr.cpp/metered/setmeteredkey/_index.md
+++ b/german/cpp/aspose.omr.cpp/metered/setmeteredkey/_index.md
@@ -1,0 +1,28 @@
+---
+title: "SetMeteredKey"
+second_title: "Aspose.OMR für .NET API-Referenz"
+description: "Setzt den Metered-öffentlichen und privaten Schlüssel"
+type: docs
+weight: 20
+url: /de/net/aspose.omr/metered/setmeteredkey/
+---
+## Metered.SetMeteredKey method
+
+Setzt den Metered-öffentlichen und privaten Schlüssel
+
+```csharp
+public void SetMeteredKey(string publicKey, string privateKey)
+```
+
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| publicKey | String | öffentlicher Schlüssel |
+| privateKey | String | privater Schlüssel |
+
+### Siehe auch
+
+* class [Metered](../../metered)
+* namespace [Aspose.OMR](../../metered)
+* assembly [Aspose.OMR](../../../)
+
+<!-- NICHT BEARBEITEN: generiert von xmldocmd für Aspose.OMR.dll -->


### PR DESCRIPTION
Automated translation of the CPP API Reference to **German** (`de`) generated by RDA.

- Pages translated: 11/11
- Errors: 0
- Source: `english/cpp`
- Output: `german/cpp`

🤖 Generated by RDA