### PR TITLE
[auto] Translate CPP API Reference to Greece

### DIFF
--- a/greece/cpp/_index.md
+++ b/greece/cpp/_index.md
@@ -1,0 +1,15 @@
+---
+title: "Aspose.OMR for C++"
+type: docs
+weight: 10
+url: /el/cpp/
+keywords: "Aspose.OMR for C++, Aspose OMR, Aspose API Reference."
+description: "Aspose.OMR for C++ είναι ένα API για την αναγνώριση οπτικών σημείων από ψηφιοποιημένες εικόνες φύλλων OMR."
+is_root: true
+---
+## Χώροι ονομάτων
+
+| Χώρος ονομάτων | Περιγραφή |
+| --- | --- |
+
+<!-- ΜΗΝ ΕΠΕΞΕΡΓΑΣΕΤΕ: δημιουργήθηκε από xmldocmd για Aspose.OMR.dll -->

--- a/greece/cpp/aspose.omr.cpp/_index.md
+++ b/greece/cpp/aspose.omr.cpp/_index.md
@@ -1,0 +1,18 @@
+---
+title: "Aspose.OMR"
+second_title: "Aspose.OMR for C++ Αναφορά API"
+description: "Το Aspose.OMR περιέχει μεθόδους αδειοδότησης."
+type: docs
+weight: 10
+url: /el/cpp/aspose.omr/
+---
+Το **Aspose.OMR** περιέχει μεθόδους αδειοδότησης.
+
+## Κλάσεις
+
+| Κλάση | Περιγραφή |
+| --- | --- |
+| [License](./license) | Παρέχει μεθόδους για την αδειοδότηση του στοιχείου. |
+| [Metered](./metered) | Παρέχει μεθόδους για τον ορισμό του μετρημένου κλειδιού. |
+
+<!-- ΜΗΝ ΕΠΕΞΕΡΓΑΣΕΤΕ: δημιουργήθηκε από xmldocmd για Aspose.OMR.dll -->

--- a/greece/cpp/aspose.omr.cpp/license/_index.md
+++ b/greece/cpp/aspose.omr.cpp/license/_index.md
@@ -1,0 +1,58 @@
+---
+title: "Άδεια"
+second_title: "Aspose.OMR for .NET Αναφορά API"
+description: "Παρέχει μεθόδους για την αδειοδότηση του στοιχείου."
+type: docs
+weight: 20
+url: /el/net/aspose.omr/license/
+---
+## License class
+
+Παρέχει μεθόδους για την αδειοδότηση του στοιχείου.
+
+```csharp
+public class License
+```
+
+## Κατασκευαστές
+
+| Όνομα | Περιγραφή |
+| --- | --- |
+| [License](license)() | Αρχικοποιεί μια νέα παρουσία αυτής της κλάσης. |
+
+## Ιδιότητες
+
+| Όνομα | Περιγραφή |
+| --- | --- |
+| [Embedded](../../aspose.omr/license/embedded) { get; set; } | Ο αριθμός άδειας προστέθηκε ως ενσωματωμένος πόρος. |
+
+## Μέθοδοι
+
+| Όνομα | Περιγραφή |
+| --- | --- |
+| [SetLicense](../../aspose.omr/license/setlicense#setlicense)(Stream) | Αδειοδοτεί το στοιχείο. |
+| [SetLicense](../../aspose.omr/license/setlicense#setlicense_1)(string) | Αδειοδοτεί το στοιχείο. |
+
+### Παραδείγματα
+
+Σε αυτό το παράδειγμα, θα γίνει προσπάθεια να βρεθεί ένα αρχείο άδειας με όνομα MyLicense.lic στον φάκελο που περιέχει το στοιχείο, στον φάκελο που περιέχει το assembly που καλεί, στον φάκελο του κύριου assembly και, στη συνέχεια, στους ενσωματωμένους πόρους του assembly που καλεί.
+
+```csharp
+[C#]
+
+License license = new License();
+license.SetLicense("MyLicense.lic");
+
+
+[Visual Basic]
+
+Dim license As license = New license
+License.SetLicense("MyLicense.lic")
+```
+
+### Δείτε επίσης
+
+* namespace [Aspose.OMR](../../aspose.omr)
+* assembly [Aspose.OMR](../../)
+
+<!-- ΜΗΝ ΕΠΕΞΕΡΓΑΣΕΤΕ: δημιουργήθηκε από xmldocmd για Aspose.OMR.dll -->

--- a/greece/cpp/aspose.omr.cpp/license/embedded/_index.md
+++ b/greece/cpp/aspose.omr.cpp/license/embedded/_index.md
@@ -1,0 +1,23 @@
+---
+title: "Ενσωματωμένο"
+second_title: "Aspose.OMR for .NET Αναφορά API"
+description: "Ο αριθμός άδειας προστέθηκε ως ενσωματωμένος πόρος."
+type: docs
+weight: 20
+url: /el/net/aspose.omr/license/embedded/
+---
+## License.Embedded property
+
+Ο αριθμός άδειας προστέθηκε ως ενσωματωμένος πόρος.
+
+```csharp
+public bool Embedded { get; set; }
+```
+
+### Δείτε επίσης
+
+* class [License](../../license)
+* namespace [Aspose.OMR](../../license)
+* assembly [Aspose.OMR](../../../)
+
+<!-- ΜΗΝ ΕΠΕΞΕΡΓΑΣΕΤΕ: δημιουργήθηκε από xmldocmd για Aspose.OMR.dll -->

--- a/greece/cpp/aspose.omr.cpp/license/license/_index.md
+++ b/greece/cpp/aspose.omr.cpp/license/license/_index.md
@@ -1,0 +1,40 @@
+---
+title: "Άδεια"
+second_title: "Aspose.OMR for .NET Αναφορά API"
+description: "Αρχικοποιεί μια νέα παρουσία αυτής της κλάσης."
+type: docs
+weight: 10
+url: /el/net/aspose.omr/license/license/
+---
+## License constructor
+
+Αρχικοποιεί μια νέα παρουσία αυτής της κλάσης.
+
+```csharp
+public License()
+```
+
+### Παραδείγματα
+
+Σε αυτό το παράδειγμα, θα γίνει προσπάθεια να βρεθεί ένα αρχείο άδειας με όνομα MyLicense.lic στον φάκελο που περιέχει το στοιχείο, στον φάκελο που περιέχει το assembly που καλεί, στον φάκελο του κύριου assembly και, στη συνέχεια, στους ενσωματωμένους πόρους του assembly που καλεί.
+
+```csharp
+[C#]
+
+License license = new License();
+license.SetLicense("MyLicense.lic");
+
+
+[Visual Basic]
+
+Dim license As license = New license
+License.SetLicense("MyLicense.lic")
+```
+
+### Δείτε επίσης
+
+* class [License](../../license)
+* namespace [Aspose.OMR](../../license)
+* assembly [Aspose.OMR](../../../)
+
+<!-- ΜΗΝ ΕΠΕΞΕΡΓΑΣΕΤΕ: δημιουργήθηκε από xmldocmd για Aspose.OMR.dll -->

--- a/greece/cpp/aspose.omr.cpp/license/setlicense/_index.md
+++ b/greece/cpp/aspose.omr.cpp/license/setlicense/_index.md
@@ -1,0 +1,101 @@
+---
+title: "SetLicense"
+second_title: "Aspose.OMR for .NET Αναφορά API"
+description: "Αδειοδοτεί το στοιχείο."
+type: docs
+weight: 30
+url: /el/net/aspose.omr/license/setlicense/
+---
+## SetLicense(string) {#setlicense_1}
+
+Αδειοδοτεί το στοιχείο.
+
+```csharp
+public void SetLicense(string licenseName)
+```
+
+### Σχόλια
+
+Προσπαθεί να βρει την άδεια στις ακόλουθες τοποθεσίες:
+
+1. Σαφής διαδρομή.
+
+2. Ο φάκελος που περιέχει το assembly του στοιχείου Aspose.
+
+3. Ο φάκελος που περιέχει το assembly που καλεί ο πελάτης.
+
+4. Ο φάκελος που περιέχει το αρχικό (startup) assembly.
+
+5. Ένας ενσωματωμένος πόρος στην assembly κλήσης του πελάτη.
+
+**Note:**On the .NET Compact Framework, tries to find the license only in these locations:
+
+1. Σαφής διαδρομή.
+
+2. Ένας ενσωματωμένος πόρος στην assembly κλήσης του πελάτη.
+
+### Παραδείγματα
+
+Σε αυτό το παράδειγμα, θα γίνει προσπάθεια να βρεθεί ένα αρχείο άδειας με όνομα MyLicense.lic στον φάκελο που περιέχει το στοιχείο, στον φάκελο που περιέχει το assembly που καλεί, στον φάκελο του κύριου assembly και, στη συνέχεια, στους ενσωματωμένους πόρους του assembly που καλεί.
+
+```csharp
+[C#]
+
+License license = new License();
+license.SetLicense("MyLicense.lic");
+
+
+[Visual Basic]
+
+Dim license As License = New License
+license.SetLicense("MyLicense.lic")
+```
+
+Μπορεί να είναι πλήρες ή σύντομο όνομα αρχείου ή όνομα ενσωματωμένου πόρου. Χρησιμοποιήστε μια κενή συμβολοσειρά για να μεταβείτε σε λειτουργία αξιολόγησης.
+
+### Δείτε επίσης
+
+* class [License](../../license)
+* namespace [Aspose.OMR](../../license)
+* assembly [Aspose.OMR](../../../)
+
+---
+
+## SetLicense(Stream) {#setlicense}
+
+Αδειοδοτεί το στοιχείο.
+
+```csharp
+public void SetLicense(Stream stream)
+```
+
+| Παράμετρος | Τύπος | Περιγραφή |
+| --- | --- | --- |
+| stream | Stream | Ένα stream που περιέχει την άδεια. |
+
+### Σχόλια
+
+Χρησιμοποιήστε αυτή τη μέθοδο για να φορτώσετε μια άδεια από ένα stream.
+
+### Παραδείγματα
+
+```csharp
+[C#]
+
+License license = new License();
+license.SetLicense(myStream);
+
+
+[Visual Basic]
+
+Dim license as License = new License
+license.SetLicense(myStream)
+```
+
+### Δείτε επίσης
+
+* class [License](../../license)
+* namespace [Aspose.OMR](../../license)
+* assembly [Aspose.OMR](../../../)
+
+<!-- ΜΗΝ ΕΠΕΞΕΡΓΑΣΕΤΕ: δημιουργήθηκε από xmldocmd για Aspose.OMR.dll -->

--- a/greece/cpp/aspose.omr.cpp/metered/_index.md
+++ b/greece/cpp/aspose.omr.cpp/metered/_index.md
@@ -1,0 +1,60 @@
+---
+title: "Μετρημένο"
+second_title: "Aspose.OMR for .NET Αναφορά API"
+description: "Παρέχει μεθόδους για τον ορισμό του μετρημένου κλειδιού."
+type: docs
+weight: 10
+url: /el/net/aspose.omr/metered/
+---
+## Metered class
+
+Παρέχει μεθόδους για τον ορισμό του μετρημένου κλειδιού.
+
+```csharp
+public class Metered
+```
+
+## Κατασκευαστές
+
+| Όνομα | Περιγραφή |
+| --- | --- |
+| [Metered](metered)() | Αρχικοποιεί μια νέα παρουσία αυτής της κλάσης. |
+
+## Μέθοδοι
+
+| Όνομα | Περιγραφή |
+| --- | --- |
+| [SetMeteredKey](../../aspose.omr/metered/setmeteredkey)(string, string) | Ορίζει το μετρημένο δημόσιο και ιδιωτικό κλειδί |
+| static [GetConsumptionCredit](../../aspose.omr/metered/getconsumptioncredit)() | Λαμβάνει πίστωση κατανάλωσης |
+| static [GetConsumptionQuantity](../../aspose.omr/metered/getconsumptionquantity)() | Λαμβάνει το μέγεθος αρχείου κατανάλωσης |
+
+### Παραδείγματα
+
+Σε αυτό το παράδειγμα, θα γίνει προσπάθεια να οριστεί το μετρημένο δημόσιο και ιδιωτικό κλειδί
+
+```csharp
+[C#]
+
+Metered matered = new Metered();
+matered.SetMeteredKey("PublicKey", "PrivateKey");
+
+
+[Visual Basic]
+
+Dim matered As Metered = New Metered
+matered.SetMeteredKey("PublicKey", "PrivateKey")
+```
+
+το αρχείο jar του στοιχείου:
+
+```csharp
+Metered matered = new Metered();
+matered.setMeteredKey("PublicKey", "PrivateKey");
+```
+
+### Δείτε επίσης
+
+* namespace [Aspose.OMR](../../aspose.omr)
+* assembly [Aspose.OMR](../../)
+
+<!-- ΜΗΝ ΕΠΕΞΕΡΓΑΣΕΤΕ: δημιουργήθηκε από xmldocmd για Aspose.OMR.dll -->

--- a/greece/cpp/aspose.omr.cpp/metered/getconsumptioncredit/_index.md
+++ b/greece/cpp/aspose.omr.cpp/metered/getconsumptioncredit/_index.md
@@ -1,0 +1,27 @@
+---
+title: "GetConsumptionCredit"
+second_title: "Aspose.OMR for .NET Αναφορά API"
+description: "Λαμβάνει πίστωση κατανάλωσης"
+type: docs
+weight: 30
+url: /el/net/aspose.omr/metered/getconsumptioncredit/
+---
+## Metered.GetConsumptionCredit method
+
+Λαμβάνει πίστωση κατανάλωσης
+
+```csharp
+public static decimal GetConsumptionCredit()
+```
+
+### Τιμή επιστροφής
+
+ποσότητα κατανάλωσης
+
+### Δείτε επίσης
+
+* class [Metered](../../metered)
+* namespace [Aspose.OMR](../../metered)
+* assembly [Aspose.OMR](../../../)
+
+<!-- ΜΗΝ ΕΠΕΞΕΡΓΑΣΕΤΕ: δημιουργήθηκε από xmldocmd για Aspose.OMR.dll -->

--- a/greece/cpp/aspose.omr.cpp/metered/getconsumptionquantity/_index.md
+++ b/greece/cpp/aspose.omr.cpp/metered/getconsumptionquantity/_index.md
@@ -1,0 +1,27 @@
+---
+title: "GetConsumptionQuantity"
+second_title: "Aspose.OMR for .NET Αναφορά API"
+description: "Λαμβάνει το μέγεθος αρχείου κατανάλωσης"
+type: docs
+weight: 40
+url: /el/net/aspose.omr/metered/getconsumptionquantity/
+---
+## Metered.GetConsumptionQuantity method
+
+Λαμβάνει το μέγεθος αρχείου κατανάλωσης
+
+```csharp
+public static decimal GetConsumptionQuantity()
+```
+
+### Τιμή επιστροφής
+
+ποσότητα κατανάλωσης
+
+### Δείτε επίσης
+
+* class [Metered](../../metered)
+* namespace [Aspose.OMR](../../metered)
+* assembly [Aspose.OMR](../../../)
+
+<!-- ΜΗΝ ΕΠΕΞΕΡΓΑΣΕΤΕ: δημιουργήθηκε από xmldocmd για Aspose.OMR.dll -->

--- a/greece/cpp/aspose.omr.cpp/metered/metered/_index.md
+++ b/greece/cpp/aspose.omr.cpp/metered/metered/_index.md
@@ -1,0 +1,23 @@
+---
+title: "Μετρημένο"
+second_title: "Aspose.OMR for .NET Αναφορά API"
+description: "Αρχικοποιεί μια νέα παρουσία αυτής της κλάσης."
+type: docs
+weight: 10
+url: /el/net/aspose.omr/metered/metered/
+---
+## Metered constructor
+
+Αρχικοποιεί μια νέα παρουσία αυτής της κλάσης.
+
+```csharp
+public Metered()
+```
+
+### Δείτε επίσης
+
+* class [Metered](../../metered)
+* namespace [Aspose.OMR](../../metered)
+* assembly [Aspose.OMR](../../../)
+
+<!-- ΜΗΝ ΕΠΕΞΕΡΓΑΣΕΤΕ: δημιουργήθηκε από xmldocmd για Aspose.OMR.dll -->

--- a/greece/cpp/aspose.omr.cpp/metered/setmeteredkey/_index.md
+++ b/greece/cpp/aspose.omr.cpp/metered/setmeteredkey/_index.md
@@ -1,0 +1,28 @@
+---
+title: "SetMeteredKey"
+second_title: "Aspose.OMR for .NET Αναφορά API"
+description: "Ορίζει το μετρημένο δημόσιο και ιδιωτικό κλειδί"
+type: docs
+weight: 20
+url: /el/net/aspose.omr/metered/setmeteredkey/
+---
+## Metered.SetMeteredKey method
+
+Ορίζει το μετρημένο δημόσιο και ιδιωτικό κλειδί
+
+```csharp
+public void SetMeteredKey(string publicKey, string privateKey)
+```
+
+| Παράμετρος | Τύπος | Περιγραφή |
+| --- | --- | --- |
+| publicKey | String | δημόσιο κλειδί |
+| privateKey | String | ιδιωτικό κλειδί |
+
+### Δείτε επίσης
+
+* class [Metered](../../metered)
+* namespace [Aspose.OMR](../../metered)
+* assembly [Aspose.OMR](../../../)
+
+<!-- ΜΗΝ ΕΠΕΞΕΡΓΑΣΕΤΕ: δημιουργήθηκε από xmldocmd για Aspose.OMR.dll -->


### PR DESCRIPTION
Automated translation of the CPP API Reference to **Greece** (`el`) generated by RDA.

- Pages translated: 11/11
- Errors: 0
- Source: `english/cpp`
- Output: `greece/cpp`

🤖 Generated by RDA