### PR TITLE
[auto] Translate CPP API Reference to Indian

### DIFF
--- a/indian/cpp/_index.md
+++ b/indian/cpp/_index.md
@@ -1,0 +1,15 @@
+---
+title: "Aspose.OMR के लिए C++"
+type: docs
+weight: 10
+url: /hi/cpp/
+keywords: "Aspose.OMR for C++, Aspose OMR, Aspose API Reference."
+description: "Aspose.OMR के लिए C++ एक API है जो OMR डिजिटाइज़्ड शीट छवियों से ऑप्टिकल मार्क्स को पहचानता है।"
+is_root: true
+---
+## नामस्थान
+
+| नामस्थान | विवरण |
+| --- | --- |
+
+<!-- संपादन न करें: xmldocmd द्वारा Aspose.OMR.dll के लिए उत्पन्न -->

--- a/indian/cpp/aspose.omr.cpp/_index.md
+++ b/indian/cpp/aspose.omr.cpp/_index.md
@@ -1,0 +1,18 @@
+---
+title: "Aspose.OMR"
+second_title: "Aspose.OMR के लिए C++ API संदर्भ"
+description: "Aspose.OMR में लाइसेंसिंग मेथड्स होते हैं।"
+type: docs
+weight: 10
+url: /hi/cpp/aspose.omr/
+---
+यह **Aspose.OMR** लाइसेंसिंग मेथड्स रखता है।
+
+## वर्ग
+
+| वर्ग | विवरण |
+| --- | --- |
+| [License](./license) | घटक को लाइसेंस करने के लिए मेथड्स प्रदान करता है। |
+| [Metered](./metered) | मीटरड कुंजी सेट करने के लिए मेथड्स प्रदान करता है। |
+
+<!-- संपादन न करें: xmldocmd द्वारा Aspose.OMR.dll के लिए उत्पन्न -->

--- a/indian/cpp/aspose.omr.cpp/license/_index.md
+++ b/indian/cpp/aspose.omr.cpp/license/_index.md
@@ -1,0 +1,58 @@
+---
+title: "लाइसेंस"
+second_title: "Aspose.OMR के लिए .NET API संदर्भ"
+description: "घटक को लाइसेंस करने के लिए मेथड्स प्रदान करता है।"
+type: docs
+weight: 20
+url: /hi/net/aspose.omr/license/
+---
+## License class
+
+घटक को लाइसेंस करने के लिए मेथड्स प्रदान करता है।
+
+```csharp
+public class License
+```
+
+## निर्माता
+
+| नाम | विवरण |
+| --- | --- |
+| [License](license)() | इस वर्ग की नई इंस्टेंस को प्रारंभ करता है। |
+
+## गुणधर्म
+
+| नाम | विवरण |
+| --- | --- |
+| [Embedded](../../aspose.omr/license/embedded) { get; set; } | लाइसेंस संख्या को एम्बेडेड संसाधन के रूप में जोड़ा गया था। |
+
+## विधियाँ
+
+| नाम | विवरण |
+| --- | --- |
+| [SetLicense](../../aspose.omr/license/setlicense#setlicense)(Stream) | घटक को लाइसेंस देता है। |
+| [SetLicense](../../aspose.omr/license/setlicense#setlicense_1)(string) | घटक को लाइसेंस देता है। |
+
+### उदाहरण
+
+इस उदाहरण में, घटक वाली फ़ोल्डर में, कॉलिंग असेंबली वाली फ़ोल्डर में, एंट्री असेंबली वाली फ़ोल्डर में, और फिर कॉलिंग असेंबली के एम्बेडेड संसाधनों में MyLicense.lic नाम की लाइसेंस फ़ाइल खोजने का प्रयास किया जाएगा।
+
+```csharp
+[C#]
+
+License license = new License();
+license.SetLicense("MyLicense.lic");
+
+
+[Visual Basic]
+
+Dim license As license = New license
+License.SetLicense("MyLicense.lic")
+```
+
+### साथ में देखें
+
+* namespace [Aspose.OMR](../../aspose.omr)
+* assembly [Aspose.OMR](../../)
+
+<!-- संपादन न करें: xmldocmd द्वारा Aspose.OMR.dll के लिए उत्पन्न -->

--- a/indian/cpp/aspose.omr.cpp/license/embedded/_index.md
+++ b/indian/cpp/aspose.omr.cpp/license/embedded/_index.md
@@ -1,0 +1,23 @@
+---
+title: "एम्बेडेड"
+second_title: "Aspose.OMR के लिए .NET API संदर्भ"
+description: "लाइसेंस संख्या को एम्बेडेड संसाधन के रूप में जोड़ा गया था।"
+type: docs
+weight: 20
+url: /hi/net/aspose.omr/license/embedded/
+---
+## License.Embedded property
+
+लाइसेंस संख्या को एम्बेडेड संसाधन के रूप में जोड़ा गया था।
+
+```csharp
+public bool Embedded { get; set; }
+```
+
+### साथ में देखें
+
+* class [License](../../license)
+* namespace [Aspose.OMR](../../license)
+* assembly [Aspose.OMR](../../../)
+
+<!-- संपादन न करें: xmldocmd द्वारा Aspose.OMR.dll के लिए उत्पन्न -->

--- a/indian/cpp/aspose.omr.cpp/license/license/_index.md
+++ b/indian/cpp/aspose.omr.cpp/license/license/_index.md
@@ -1,0 +1,40 @@
+---
+title: "लाइसेंस"
+second_title: "Aspose.OMR के लिए .NET API संदर्भ"
+description: "इस वर्ग की नई इंस्टेंस को प्रारंभ करता है।"
+type: docs
+weight: 10
+url: /hi/net/aspose.omr/license/license/
+---
+## License constructor
+
+इस वर्ग की नई इंस्टेंस को प्रारंभ करता है।
+
+```csharp
+public License()
+```
+
+### उदाहरण
+
+इस उदाहरण में, घटक वाली फ़ोल्डर में, कॉलिंग असेंबली वाली फ़ोल्डर में, एंट्री असेंबली वाली फ़ोल्डर में, और फिर कॉलिंग असेंबली के एम्बेडेड संसाधनों में MyLicense.lic नाम की लाइसेंस फ़ाइल खोजने का प्रयास किया जाएगा।
+
+```csharp
+[C#]
+
+License license = new License();
+license.SetLicense("MyLicense.lic");
+
+
+[Visual Basic]
+
+Dim license As license = New license
+License.SetLicense("MyLicense.lic")
+```
+
+### साथ में देखें
+
+* class [License](../../license)
+* namespace [Aspose.OMR](../../license)
+* assembly [Aspose.OMR](../../../)
+
+<!-- संपादन न करें: xmldocmd द्वारा Aspose.OMR.dll के लिए उत्पन्न -->

--- a/indian/cpp/aspose.omr.cpp/license/setlicense/_index.md
+++ b/indian/cpp/aspose.omr.cpp/license/setlicense/_index.md
@@ -1,0 +1,101 @@
+---
+title: "SetLicense"
+second_title: "Aspose.OMR के लिए .NET API संदर्भ"
+description: "घटक को लाइसेंस देता है।"
+type: docs
+weight: 30
+url: /hi/net/aspose.omr/license/setlicense/
+---
+## SetLicense(string) {#setlicense_1}
+
+घटक को लाइसेंस देता है।
+
+```csharp
+public void SetLicense(string licenseName)
+```
+
+### टिप्पणियाँ
+
+निम्नलिखित स्थानों में लाइसेंस खोजने का प्रयास करता है:
+
+1. स्पष्ट पथ।
+
+2. Aspose घटक असेंबली वाली फ़ोल्डर।
+
+3. क्लाइंट की कॉलिंग असेंबली वाली फ़ोल्डर।
+
+4. एंट्री (स्टार्टअप) असेंबली को शामिल करने वाला फ़ोल्डर।
+
+5. क्लाइंट की कॉलिंग असेंबली में एक एम्बेडेड रिसोर्स।
+
+**Note:**On the .NET Compact Framework, tries to find the license only in these locations:
+
+1. स्पष्ट पथ।
+
+2. क्लाइंट की कॉलिंग असेंबली में एक एम्बेडेड रिसोर्स।
+
+### उदाहरण
+
+इस उदाहरण में, घटक वाली फ़ोल्डर में, कॉलिंग असेंबली वाली फ़ोल्डर में, एंट्री असेंबली वाली फ़ोल्डर में, और फिर कॉलिंग असेंबली के एम्बेडेड संसाधनों में MyLicense.lic नाम की लाइसेंस फ़ाइल खोजने का प्रयास किया जाएगा।
+
+```csharp
+[C#]
+
+License license = new License();
+license.SetLicense("MyLicense.lic");
+
+
+[Visual Basic]
+
+Dim license As License = New License
+license.SetLicense("MyLicense.lic")
+```
+
+पूरा या छोटा फ़ाइल नाम या एम्बेडेड रिसोर्स का नाम हो सकता है। मूल्यांकन मोड में स्विच करने के लिए खाली स्ट्रिंग का उपयोग करें।
+
+### साथ में देखें
+
+* class [License](../../license)
+* namespace [Aspose.OMR](../../license)
+* assembly [Aspose.OMR](../../../)
+
+---
+
+## SetLicense(Stream) {#setlicense}
+
+घटक को लाइसेंस देता है।
+
+```csharp
+public void SetLicense(Stream stream)
+```
+
+| पैरामीटर | प्रकार | विवरण |
+| --- | --- | --- |
+| स्ट्रीम | स्ट्रीम | एक स्ट्रीम जिसमें लाइसेंस शामिल है। |
+
+### टिप्पणियाँ
+
+इस मेथड का उपयोग करके स्ट्रीम से लाइसेंस लोड करें।
+
+### उदाहरण
+
+```csharp
+[C#]
+
+License license = new License();
+license.SetLicense(myStream);
+
+
+[Visual Basic]
+
+Dim license as License = new License
+license.SetLicense(myStream)
+```
+
+### साथ में देखें
+
+* class [License](../../license)
+* namespace [Aspose.OMR](../../license)
+* assembly [Aspose.OMR](../../../)
+
+<!-- संपादन न करें: xmldocmd द्वारा Aspose.OMR.dll के लिए उत्पन्न -->

--- a/indian/cpp/aspose.omr.cpp/metered/_index.md
+++ b/indian/cpp/aspose.omr.cpp/metered/_index.md
@@ -1,0 +1,60 @@
+---
+title: "मीटरड"
+second_title: "Aspose.OMR के लिए .NET API संदर्भ"
+description: "मीटरड कुंजी सेट करने के लिए मेथड्स प्रदान करता है।"
+type: docs
+weight: 10
+url: /hi/net/aspose.omr/metered/
+---
+## Metered class
+
+मीटरड कुंजी सेट करने के लिए मेथड्स प्रदान करता है।
+
+```csharp
+public class Metered
+```
+
+## निर्माता
+
+| नाम | विवरण |
+| --- | --- |
+| [Metered](metered)() | इस वर्ग की नई इंस्टेंस को प्रारंभ करता है। |
+
+## विधियाँ
+
+| नाम | विवरण |
+| --- | --- |
+| [SetMeteredKey](../../aspose.omr/metered/setmeteredkey)(string, string) | मीटरड सार्वजनिक और निजी कुंजी सेट करता है। |
+| static [GetConsumptionCredit](../../aspose.omr/metered/getconsumptioncredit)() | उपभोग क्रेडिट प्राप्त करता है। |
+| static [GetConsumptionQuantity](../../aspose.omr/metered/getconsumptionquantity)() | उपभोग फ़ाइल आकार प्राप्त करता है। |
+
+### उदाहरण
+
+इस उदाहरण में, मीटरड सार्वजनिक और निजी कुंजी सेट करने का प्रयास किया जाएगा।
+
+```csharp
+[C#]
+
+Metered matered = new Metered();
+matered.SetMeteredKey("PublicKey", "PrivateKey");
+
+
+[Visual Basic]
+
+Dim matered As Metered = New Metered
+matered.SetMeteredKey("PublicKey", "PrivateKey")
+```
+
+घटक जार फ़ाइल:
+
+```csharp
+Metered matered = new Metered();
+matered.setMeteredKey("PublicKey", "PrivateKey");
+```
+
+### साथ में देखें
+
+* namespace [Aspose.OMR](../../aspose.omr)
+* assembly [Aspose.OMR](../../)
+
+<!-- संपादन न करें: xmldocmd द्वारा Aspose.OMR.dll के लिए उत्पन्न -->

--- a/indian/cpp/aspose.omr.cpp/metered/getconsumptioncredit/_index.md
+++ b/indian/cpp/aspose.omr.cpp/metered/getconsumptioncredit/_index.md
@@ -1,0 +1,27 @@
+---
+title: "GetConsumptionCredit"
+second_title: "Aspose.OMR के लिए .NET API संदर्भ"
+description: "उपभोग क्रेडिट प्राप्त करता है।"
+type: docs
+weight: 30
+url: /hi/net/aspose.omr/metered/getconsumptioncredit/
+---
+## Metered.GetConsumptionCredit method
+
+उपभोग क्रेडिट प्राप्त करता है।
+
+```csharp
+public static decimal GetConsumptionCredit()
+```
+
+### वापसी मान
+
+उपभोग मात्रा
+
+### साथ में देखें
+
+* class [Metered](../../metered)
+* namespace [Aspose.OMR](../../metered)
+* assembly [Aspose.OMR](../../../)
+
+<!-- संपादन न करें: xmldocmd द्वारा Aspose.OMR.dll के लिए उत्पन्न -->

--- a/indian/cpp/aspose.omr.cpp/metered/getconsumptionquantity/_index.md
+++ b/indian/cpp/aspose.omr.cpp/metered/getconsumptionquantity/_index.md
@@ -1,0 +1,27 @@
+---
+title: "GetConsumptionQuantity"
+second_title: "Aspose.OMR के लिए .NET API संदर्भ"
+description: "उपभोग फ़ाइल आकार प्राप्त करता है।"
+type: docs
+weight: 40
+url: /hi/net/aspose.omr/metered/getconsumptionquantity/
+---
+## Metered.GetConsumptionQuantity method
+
+उपभोग फ़ाइल आकार प्राप्त करता है।
+
+```csharp
+public static decimal GetConsumptionQuantity()
+```
+
+### वापसी मान
+
+उपभोग मात्रा
+
+### साथ में देखें
+
+* class [Metered](../../metered)
+* namespace [Aspose.OMR](../../metered)
+* assembly [Aspose.OMR](../../../)
+
+<!-- संपादन न करें: xmldocmd द्वारा Aspose.OMR.dll के लिए उत्पन्न -->

--- a/indian/cpp/aspose.omr.cpp/metered/metered/_index.md
+++ b/indian/cpp/aspose.omr.cpp/metered/metered/_index.md
@@ -1,0 +1,23 @@
+---
+title: "मीटरड"
+second_title: "Aspose.OMR के लिए .NET API संदर्भ"
+description: "इस वर्ग की नई इंस्टेंस को प्रारंभ करता है।"
+type: docs
+weight: 10
+url: /hi/net/aspose.omr/metered/metered/
+---
+## Metered constructor
+
+इस वर्ग की नई इंस्टेंस को प्रारंभ करता है।
+
+```csharp
+public Metered()
+```
+
+### साथ में देखें
+
+* class [Metered](../../metered)
+* namespace [Aspose.OMR](../../metered)
+* assembly [Aspose.OMR](../../../)
+
+<!-- संपादन न करें: xmldocmd द्वारा Aspose.OMR.dll के लिए उत्पन्न -->

--- a/indian/cpp/aspose.omr.cpp/metered/setmeteredkey/_index.md
+++ b/indian/cpp/aspose.omr.cpp/metered/setmeteredkey/_index.md
@@ -1,0 +1,28 @@
+---
+title: "SetMeteredKey"
+second_title: "Aspose.OMR के लिए .NET API संदर्भ"
+description: "मीटरड सार्वजनिक और निजी कुंजी सेट करता है।"
+type: docs
+weight: 20
+url: /hi/net/aspose.omr/metered/setmeteredkey/
+---
+## Metered.SetMeteredKey method
+
+मीटरड सार्वजनिक और निजी कुंजी सेट करता है।
+
+```csharp
+public void SetMeteredKey(string publicKey, string privateKey)
+```
+
+| पैरामीटर | प्रकार | विवरण |
+| --- | --- | --- |
+| publicKey | String | सार्वजनिक कुंजी |
+| privateKey | String | निजी कुंजी |
+
+### साथ में देखें
+
+* class [Metered](../../metered)
+* namespace [Aspose.OMR](../../metered)
+* assembly [Aspose.OMR](../../../)
+
+<!-- संपादन न करें: xmldocmd द्वारा Aspose.OMR.dll के लिए उत्पन्न -->


### PR DESCRIPTION
Automated translation of the CPP API Reference to **Indian** (`hi`) generated by RDA.

- Pages translated: 11/11
- Errors: 0
- Source: `english/cpp`
- Output: `indian/cpp`

🤖 Generated by RDA