### PR TITLE
[auto] Translate CPP API Reference to Italian

### DIFF
--- a/italian/cpp/_index.md
+++ b/italian/cpp/_index.md
@@ -1,0 +1,15 @@
+---
+title: "Aspose.OMR per C++"
+type: docs
+weight: 10
+url: /it/cpp/
+keywords: "Aspose.OMR for C++, Aspose OMR, Aspose API Reference."
+description: "Aspose.OMR per C++ è un'API per riconoscere i segni ottici da immagini di fogli digitalizzati OMR."
+is_root: true
+---
+## Spazi dei nomi
+
+| Spazio dei nomi | Descrizione |
+| --- | --- |
+
+<!-- NON MODIFICARE: generato da xmldocmd per Aspose.OMR.dll -->

--- a/italian/cpp/aspose.omr.cpp/_index.md
+++ b/italian/cpp/aspose.omr.cpp/_index.md
@@ -1,0 +1,18 @@
+---
+title: "Aspose.OMR"
+second_title: "Riferimento API Aspose.OMR per C++"
+description: "Aspose.OMR contiene i metodi di licenza."
+type: docs
+weight: 10
+url: /it/cpp/aspose.omr/
+---
+**Aspose.OMR** contiene i metodi di licenza.
+
+## Classi
+
+| Classe | Descrizione |
+| --- | --- |
+| [License](./license) | Fornisce metodi per licenziare il componente. |
+| [Metered](./metered) | Fornisce metodi per impostare la chiave a consumo. |
+
+<!-- NON MODIFICARE: generato da xmldocmd per Aspose.OMR.dll -->

--- a/italian/cpp/aspose.omr.cpp/license/_index.md
+++ b/italian/cpp/aspose.omr.cpp/license/_index.md
@@ -1,0 +1,58 @@
+---
+title: "Licenza"
+second_title: "Riferimento API Aspose.OMR per .NET"
+description: "Fornisce metodi per licenziare il componente."
+type: docs
+weight: 20
+url: /it/net/aspose.omr/license/
+---
+## License class
+
+Fornisce metodi per licenziare il componente.
+
+```csharp
+public class License
+```
+
+## Costruttori
+
+| Nome | Descrizione |
+| --- | --- |
+| [License](license)() | Inizializza una nuova istanza di questa classe. |
+
+## Proprietà
+
+| Nome | Descrizione |
+| --- | --- |
+| [Embedded](../../aspose.omr/license/embedded) { get; set; } | Il numero di licenza è stato aggiunto come risorsa incorporata. |
+
+## Metodi
+
+| Nome | Descrizione |
+| --- | --- |
+| [SetLicense](../../aspose.omr/license/setlicense#setlicense)(Stream) | Concede licenza al componente. |
+| [SetLicense](../../aspose.omr/license/setlicense#setlicense_1)(string) | Concede licenza al componente. |
+
+### Esempi
+
+In questo esempio, si cercherà di trovare un file di licenza denominato MyLicense.lic nella cartella che contiene il componente, nella cartella che contiene l'assembly chiamante, nella cartella dell'assembly di ingresso e quindi nelle risorse incorporate dell'assembly chiamante.
+
+```csharp
+[C#]
+
+License license = new License();
+license.SetLicense("MyLicense.lic");
+
+
+[Visual Basic]
+
+Dim license As license = New license
+License.SetLicense("MyLicense.lic")
+```
+
+### Vedi anche
+
+* namespace [Aspose.OMR](../../aspose.omr)
+* assembly [Aspose.OMR](../../)
+
+<!-- NON MODIFICARE: generato da xmldocmd per Aspose.OMR.dll -->

--- a/italian/cpp/aspose.omr.cpp/license/embedded/_index.md
+++ b/italian/cpp/aspose.omr.cpp/license/embedded/_index.md
@@ -1,0 +1,23 @@
+---
+title: "Incorporato"
+second_title: "Riferimento API Aspose.OMR per .NET"
+description: "Il numero di licenza è stato aggiunto come risorsa incorporata."
+type: docs
+weight: 20
+url: /it/net/aspose.omr/license/embedded/
+---
+## License.Embedded property
+
+Il numero di licenza è stato aggiunto come risorsa incorporata.
+
+```csharp
+public bool Embedded { get; set; }
+```
+
+### Vedi anche
+
+* class [License](../../license)
+* namespace [Aspose.OMR](../../license)
+* assembly [Aspose.OMR](../../../)
+
+<!-- NON MODIFICARE: generato da xmldocmd per Aspose.OMR.dll -->

--- a/italian/cpp/aspose.omr.cpp/license/license/_index.md
+++ b/italian/cpp/aspose.omr.cpp/license/license/_index.md
@@ -1,0 +1,40 @@
+---
+title: "Licenza"
+second_title: "Riferimento API Aspose.OMR per .NET"
+description: "Inizializza una nuova istanza di questa classe."
+type: docs
+weight: 10
+url: /it/net/aspose.omr/license/license/
+---
+## License constructor
+
+Inizializza una nuova istanza di questa classe.
+
+```csharp
+public License()
+```
+
+### Esempi
+
+In questo esempio, si cercherà di trovare un file di licenza denominato MyLicense.lic nella cartella che contiene il componente, nella cartella che contiene l'assembly chiamante, nella cartella dell'assembly di ingresso e quindi nelle risorse incorporate dell'assembly chiamante.
+
+```csharp
+[C#]
+
+License license = new License();
+license.SetLicense("MyLicense.lic");
+
+
+[Visual Basic]
+
+Dim license As license = New license
+License.SetLicense("MyLicense.lic")
+```
+
+### Vedi anche
+
+* class [License](../../license)
+* namespace [Aspose.OMR](../../license)
+* assembly [Aspose.OMR](../../../)
+
+<!-- NON MODIFICARE: generato da xmldocmd per Aspose.OMR.dll -->

--- a/italian/cpp/aspose.omr.cpp/license/setlicense/_index.md
+++ b/italian/cpp/aspose.omr.cpp/license/setlicense/_index.md
@@ -1,0 +1,101 @@
+---
+title: "SetLicense"
+second_title: "Riferimento API Aspose.OMR per .NET"
+description: "Concede licenza al componente."
+type: docs
+weight: 30
+url: /it/net/aspose.omr/license/setlicense/
+---
+## SetLicense(string) {#setlicense_1}
+
+Concede licenza al componente.
+
+```csharp
+public void SetLicense(string licenseName)
+```
+
+### Osservazioni
+
+Cerca di trovare la licenza nei seguenti percorsi:
+
+1. Percorso esplicito.
+
+2. La cartella che contiene l'assembly del componente Aspose.
+
+3. La cartella che contiene l'assembly chiamante del cliente.
+
+4. La cartella che contiene l'assembly di avvio (entry).
+
+5. Una risorsa incorporata nell'assembly chiamante del client.
+
+**Note:**On the .NET Compact Framework, tries to find the license only in these locations:
+
+1. Percorso esplicito.
+
+2. Una risorsa incorporata nell'assembly chiamante del client.
+
+### Esempi
+
+In questo esempio, si cercherà di trovare un file di licenza denominato MyLicense.lic nella cartella che contiene il componente, nella cartella che contiene l'assembly chiamante, nella cartella dell'assembly di ingresso e quindi nelle risorse incorporate dell'assembly chiamante.
+
+```csharp
+[C#]
+
+License license = new License();
+license.SetLicense("MyLicense.lic");
+
+
+[Visual Basic]
+
+Dim license As License = New License
+license.SetLicense("MyLicense.lic")
+```
+
+Può essere un nome file completo o breve o il nome di una risorsa incorporata. Usa una stringa vuota per passare alla modalità di valutazione.
+
+### Vedi anche
+
+* class [License](../../license)
+* namespace [Aspose.OMR](../../license)
+* assembly [Aspose.OMR](../../../)
+
+---
+
+## SetLicense(Stream) {#setlicense}
+
+Concede licenza al componente.
+
+```csharp
+public void SetLicense(Stream stream)
+```
+
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| stream | Stream | Un flusso che contiene la licenza. |
+
+### Osservazioni
+
+Usa questo metodo per caricare una licenza da un flusso.
+
+### Esempi
+
+```csharp
+[C#]
+
+License license = new License();
+license.SetLicense(myStream);
+
+
+[Visual Basic]
+
+Dim license as License = new License
+license.SetLicense(myStream)
+```
+
+### Vedi anche
+
+* class [License](../../license)
+* namespace [Aspose.OMR](../../license)
+* assembly [Aspose.OMR](../../../)
+
+<!-- NON MODIFICARE: generato da xmldocmd per Aspose.OMR.dll -->

--- a/italian/cpp/aspose.omr.cpp/metered/_index.md
+++ b/italian/cpp/aspose.omr.cpp/metered/_index.md
@@ -1,0 +1,60 @@
+---
+title: "A consumo"
+second_title: "Riferimento API Aspose.OMR per .NET"
+description: "Fornisce metodi per impostare la chiave a consumo."
+type: docs
+weight: 10
+url: /it/net/aspose.omr/metered/
+---
+## Metered class
+
+Fornisce metodi per impostare la chiave a consumo.
+
+```csharp
+public class Metered
+```
+
+## Costruttori
+
+| Nome | Descrizione |
+| --- | --- |
+| [Metered](metered)() | Inizializza una nuova istanza di questa classe. |
+
+## Metodi
+
+| Nome | Descrizione |
+| --- | --- |
+| [SetMeteredKey](../../aspose.omr/metered/setmeteredkey)(string, string) | Imposta la chiave pubblica e privata a consumo |
+| static [GetConsumptionCredit](../../aspose.omr/metered/getconsumptioncredit)() | Ottiene il credito di consumo |
+| static [GetConsumptionQuantity](../../aspose.omr/metered/getconsumptionquantity)() | Ottiene la dimensione del file di consumo |
+
+### Esempi
+
+In questo esempio, verrà tentato di impostare la chiave pubblica e privata a consumo
+
+```csharp
+[C#]
+
+Metered matered = new Metered();
+matered.SetMeteredKey("PublicKey", "PrivateKey");
+
+
+[Visual Basic]
+
+Dim matered As Metered = New Metered
+matered.SetMeteredKey("PublicKey", "PrivateKey")
+```
+
+il file jar del componente:
+
+```csharp
+Metered matered = new Metered();
+matered.setMeteredKey("PublicKey", "PrivateKey");
+```
+
+### Vedi anche
+
+* namespace [Aspose.OMR](../../aspose.omr)
+* assembly [Aspose.OMR](../../)
+
+<!-- NON MODIFICARE: generato da xmldocmd per Aspose.OMR.dll -->

--- a/italian/cpp/aspose.omr.cpp/metered/getconsumptioncredit/_index.md
+++ b/italian/cpp/aspose.omr.cpp/metered/getconsumptioncredit/_index.md
@@ -1,0 +1,27 @@
+---
+title: "GetConsumptionCredit"
+second_title: "Riferimento API Aspose.OMR per .NET"
+description: "Ottiene il credito di consumo"
+type: docs
+weight: 30
+url: /it/net/aspose.omr/metered/getconsumptioncredit/
+---
+## Metered.GetConsumptionCredit method
+
+Ottiene il credito di consumo
+
+```csharp
+public static decimal GetConsumptionCredit()
+```
+
+### Valore restituito
+
+quantità di consumo
+
+### Vedi anche
+
+* class [Metered](../../metered)
+* namespace [Aspose.OMR](../../metered)
+* assembly [Aspose.OMR](../../../)
+
+<!-- NON MODIFICARE: generato da xmldocmd per Aspose.OMR.dll -->

--- a/italian/cpp/aspose.omr.cpp/metered/getconsumptionquantity/_index.md
+++ b/italian/cpp/aspose.omr.cpp/metered/getconsumptionquantity/_index.md
@@ -1,0 +1,27 @@
+---
+title: "GetConsumptionQuantity"
+second_title: "Riferimento API Aspose.OMR per .NET"
+description: "Ottiene la dimensione del file di consumo"
+type: docs
+weight: 40
+url: /it/net/aspose.omr/metered/getconsumptionquantity/
+---
+## Metered.GetConsumptionQuantity method
+
+Ottiene la dimensione del file di consumo
+
+```csharp
+public static decimal GetConsumptionQuantity()
+```
+
+### Valore restituito
+
+quantità di consumo
+
+### Vedi anche
+
+* class [Metered](../../metered)
+* namespace [Aspose.OMR](../../metered)
+* assembly [Aspose.OMR](../../../)
+
+<!-- NON MODIFICARE: generato da xmldocmd per Aspose.OMR.dll -->

--- a/italian/cpp/aspose.omr.cpp/metered/metered/_index.md
+++ b/italian/cpp/aspose.omr.cpp/metered/metered/_index.md
@@ -1,0 +1,23 @@
+---
+title: "A consumo"
+second_title: "Riferimento API Aspose.OMR per .NET"
+description: "Inizializza una nuova istanza di questa classe."
+type: docs
+weight: 10
+url: /it/net/aspose.omr/metered/metered/
+---
+## Metered constructor
+
+Inizializza una nuova istanza di questa classe.
+
+```csharp
+public Metered()
+```
+
+### Vedi anche
+
+* class [Metered](../../metered)
+* namespace [Aspose.OMR](../../metered)
+* assembly [Aspose.OMR](../../../)
+
+<!-- NON MODIFICARE: generato da xmldocmd per Aspose.OMR.dll -->

--- a/italian/cpp/aspose.omr.cpp/metered/setmeteredkey/_index.md
+++ b/italian/cpp/aspose.omr.cpp/metered/setmeteredkey/_index.md
@@ -1,0 +1,28 @@
+---
+title: "SetMeteredKey"
+second_title: "Riferimento API Aspose.OMR per .NET"
+description: "Imposta la chiave pubblica e privata a consumo"
+type: docs
+weight: 20
+url: /it/net/aspose.omr/metered/setmeteredkey/
+---
+## Metered.SetMeteredKey method
+
+Imposta la chiave pubblica e privata a consumo
+
+```csharp
+public void SetMeteredKey(string publicKey, string privateKey)
+```
+
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| publicKey | Stringa | chiave pubblica |
+| privateKey | Stringa | chiave privata |
+
+### Vedi anche
+
+* class [Metered](../../metered)
+* namespace [Aspose.OMR](../../metered)
+* assembly [Aspose.OMR](../../../)
+
+<!-- NON MODIFICARE: generato da xmldocmd per Aspose.OMR.dll -->


### PR DESCRIPTION
Automated translation of the CPP API Reference to **Italian** (`it`) generated by RDA.

- Pages translated: 11/11
- Errors: 0
- Source: `english/cpp`
- Output: `italian/cpp`

🤖 Generated by RDA