### PR TITLE
[auto] Translate CPP API Reference to Japanese

### DIFF
--- a/japanese/cpp/_index.md
+++ b/japanese/cpp/_index.md
@@ -1,0 +1,15 @@
+---
+title: "C++ 用 Aspose.OMR"
+type: docs
+weight: 10
+url: /ja/cpp/
+keywords: "Aspose.OMR for C++, Aspose OMR, Aspose API Reference."
+description: "C++ 用 Aspose.OMR は、OMR デジタル化シート画像から光学マークを認識するための API です。"
+is_root: true
+---
+## 名前空間
+
+| 名前空間 | 説明 |
+| --- | --- |
+
+<!-- 編集しないでください: xmldocmd によって Aspose.OMR.dll 用に生成されました -->

--- a/japanese/cpp/aspose.omr.cpp/_index.md
+++ b/japanese/cpp/aspose.omr.cpp/_index.md
@@ -1,0 +1,18 @@
+---
+title: "Aspose.OMR"
+second_title: "C++ 用 Aspose.OMR API リファレンス"
+description: "Aspose.OMR にはライセンス メソッドが含まれています。"
+type: docs
+weight: 10
+url: /ja/cpp/aspose.omr/
+---
+**Aspose.OMR** にはライセンス メソッドが含まれています。
+
+## クラス
+
+| クラス | 説明 |
+| --- | --- |
+| [License](./license) | コンポーネントにライセンスを付与するメソッドを提供します。 |
+| [Metered](./metered) | メーターキーを設定するメソッドを提供します。 |
+
+<!-- 編集しないでください: xmldocmd によって Aspose.OMR.dll 用に生成されました -->

--- a/japanese/cpp/aspose.omr.cpp/license/_index.md
+++ b/japanese/cpp/aspose.omr.cpp/license/_index.md
@@ -1,0 +1,58 @@
+---
+title: "ライセンス"
+second_title: ".NET 用 Aspose.OMR API リファレンス"
+description: "コンポーネントにライセンスを付与するメソッドを提供します。"
+type: docs
+weight: 20
+url: /ja/net/aspose.omr/license/
+---
+## License class
+
+コンポーネントにライセンスを付与するメソッドを提供します。
+
+```csharp
+public class License
+```
+
+## コンストラクタ
+
+| 名前 | 説明 |
+| --- | --- |
+| [License](license)() | このクラスの新しいインスタンスを初期化します。 |
+
+## プロパティ
+
+| 名前 | 説明 |
+| --- | --- |
+| [Embedded](../../aspose.omr/license/embedded) { get; set; } | ライセンス番号が埋め込みリソースとして追加されました。 |
+
+## メソッド
+
+| 名前 | 説明 |
+| --- | --- |
+| [SetLicense](../../aspose.omr/license/setlicense#setlicense)(Stream) | コンポーネントにライセンスを付与します。 |
+| [SetLicense](../../aspose.omr/license/setlicense#setlicense_1)(string) | コンポーネントにライセンスを付与します。 |
+
+### 例
+
+この例では、コンポーネントが含まれるフォルダー、呼び出しアセンブリが含まれるフォルダー、エントリ アセンブリのフォルダー、そして呼び出しアセンブリの埋め込みリソース内で、MyLicense.lic という名前のライセンス ファイルを検索しようとします。
+
+```csharp
+[C#]
+
+License license = new License();
+license.SetLicense("MyLicense.lic");
+
+
+[Visual Basic]
+
+Dim license As license = New license
+License.SetLicense("MyLicense.lic")
+```
+
+### 参照
+
+* namespace [Aspose.OMR](../../aspose.omr)
+* assembly [Aspose.OMR](../../)
+
+<!-- 編集しないでください: xmldocmd によって Aspose.OMR.dll 用に生成されました -->

--- a/japanese/cpp/aspose.omr.cpp/license/embedded/_index.md
+++ b/japanese/cpp/aspose.omr.cpp/license/embedded/_index.md
@@ -1,0 +1,23 @@
+---
+title: "埋め込み"
+second_title: ".NET 用 Aspose.OMR API リファレンス"
+description: "ライセンス番号が埋め込みリソースとして追加されました。"
+type: docs
+weight: 20
+url: /ja/net/aspose.omr/license/embedded/
+---
+## License.Embedded property
+
+ライセンス番号が埋め込みリソースとして追加されました。
+
+```csharp
+public bool Embedded { get; set; }
+```
+
+### 参照
+
+* class [License](../../license)
+* namespace [Aspose.OMR](../../license)
+* assembly [Aspose.OMR](../../../)
+
+<!-- 編集しないでください: xmldocmd によって Aspose.OMR.dll 用に生成されました -->

--- a/japanese/cpp/aspose.omr.cpp/license/license/_index.md
+++ b/japanese/cpp/aspose.omr.cpp/license/license/_index.md
@@ -1,0 +1,40 @@
+---
+title: "ライセンス"
+second_title: ".NET 用 Aspose.OMR API リファレンス"
+description: "このクラスの新しいインスタンスを初期化します。"
+type: docs
+weight: 10
+url: /ja/net/aspose.omr/license/license/
+---
+## License constructor
+
+このクラスの新しいインスタンスを初期化します。
+
+```csharp
+public License()
+```
+
+### 例
+
+この例では、コンポーネントが含まれるフォルダー、呼び出しアセンブリが含まれるフォルダー、エントリ アセンブリのフォルダー、そして呼び出しアセンブリの埋め込みリソース内で、MyLicense.lic という名前のライセンス ファイルを検索しようとします。
+
+```csharp
+[C#]
+
+License license = new License();
+license.SetLicense("MyLicense.lic");
+
+
+[Visual Basic]
+
+Dim license As license = New license
+License.SetLicense("MyLicense.lic")
+```
+
+### 参照
+
+* class [License](../../license)
+* namespace [Aspose.OMR](../../license)
+* assembly [Aspose.OMR](../../../)
+
+<!-- 編集しないでください: xmldocmd によって Aspose.OMR.dll 用に生成されました -->

--- a/japanese/cpp/aspose.omr.cpp/license/setlicense/_index.md
+++ b/japanese/cpp/aspose.omr.cpp/license/setlicense/_index.md
@@ -1,0 +1,101 @@
+---
+title: "SetLicense"
+second_title: ".NET 用 Aspose.OMR API リファレンス"
+description: "コンポーネントにライセンスを付与します。"
+type: docs
+weight: 30
+url: /ja/net/aspose.omr/license/setlicense/
+---
+## SetLicense(string) {#setlicense_1}
+
+コンポーネントにライセンスを付与します。
+
+```csharp
+public void SetLicense(string licenseName)
+```
+
+### 備考
+
+次の場所でライセンスを検索しようとします:
+
+1. 明示的なパス。
+
+2. Aspose コンポーネント アセンブリが含まれるフォルダー。
+
+3. クライアントの呼び出しアセンブリが含まれるフォルダー。
+
+4. エントリ（スタートアップ）アセンブリを含むフォルダーです。
+
+5. クライアントの呼び出しアセンブリ内の埋め込みリソースです。
+
+**Note:**On the .NET Compact Framework, tries to find the license only in these locations:
+
+1. 明示的なパス。
+
+2. クライアントの呼び出しアセンブリ内の埋め込みリソースです。
+
+### 例
+
+この例では、コンポーネントが含まれるフォルダー、呼び出しアセンブリが含まれるフォルダー、エントリ アセンブリのフォルダー、そして呼び出しアセンブリの埋め込みリソース内で、MyLicense.lic という名前のライセンス ファイルを検索しようとします。
+
+```csharp
+[C#]
+
+License license = new License();
+license.SetLicense("MyLicense.lic");
+
+
+[Visual Basic]
+
+Dim license As License = New License
+license.SetLicense("MyLicense.lic")
+```
+
+完全または短いファイル名、または埋め込みリソースの名前を指定できます。空文字列を使用すると評価モードに切り替わります。
+
+### 参照
+
+* class [License](../../license)
+* namespace [Aspose.OMR](../../license)
+* assembly [Aspose.OMR](../../../)
+
+---
+
+## SetLicense(Stream) {#setlicense}
+
+コンポーネントにライセンスを付与します。
+
+```csharp
+public void SetLicense(Stream stream)
+```
+
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| ストリーム | ストリーム | ライセンスを含むストリームです。 |
+
+### 備考
+
+このメソッドを使用して、ストリームからライセンスをロードします。
+
+### 例
+
+```csharp
+[C#]
+
+License license = new License();
+license.SetLicense(myStream);
+
+
+[Visual Basic]
+
+Dim license as License = new License
+license.SetLicense(myStream)
+```
+
+### 参照
+
+* class [License](../../license)
+* namespace [Aspose.OMR](../../license)
+* assembly [Aspose.OMR](../../../)
+
+<!-- 編集しないでください: xmldocmd によって Aspose.OMR.dll 用に生成されました -->

--- a/japanese/cpp/aspose.omr.cpp/metered/_index.md
+++ b/japanese/cpp/aspose.omr.cpp/metered/_index.md
@@ -1,0 +1,60 @@
+---
+title: "メーター制"
+second_title: ".NET 用 Aspose.OMR API リファレンス"
+description: "メーターキーを設定するメソッドを提供します。"
+type: docs
+weight: 10
+url: /ja/net/aspose.omr/metered/
+---
+## Metered class
+
+メーターキーを設定するメソッドを提供します。
+
+```csharp
+public class Metered
+```
+
+## コンストラクタ
+
+| 名前 | 説明 |
+| --- | --- |
+| [Metered](metered)() | このクラスの新しいインスタンスを初期化します。 |
+
+## メソッド
+
+| 名前 | 説明 |
+| --- | --- |
+| [SetMeteredKey](../../aspose.omr/metered/setmeteredkey)(string, string) | メーター制の公開キーとプライベートキーを設定します。 |
+| static [GetConsumptionCredit](../../aspose.omr/metered/getconsumptioncredit)() | 消費クレジットを取得します。 |
+| static [GetConsumptionQuantity](../../aspose.omr/metered/getconsumptionquantity)() | 消費ファイルサイズを取得します。 |
+
+### 例
+
+この例では、メーター制の公開キーとプライベートキーを設定しようとします。
+
+```csharp
+[C#]
+
+Metered matered = new Metered();
+matered.SetMeteredKey("PublicKey", "PrivateKey");
+
+
+[Visual Basic]
+
+Dim matered As Metered = New Metered
+matered.SetMeteredKey("PublicKey", "PrivateKey")
+```
+
+コンポーネントの JAR ファイル:
+
+```csharp
+Metered matered = new Metered();
+matered.setMeteredKey("PublicKey", "PrivateKey");
+```
+
+### 参照
+
+* namespace [Aspose.OMR](../../aspose.omr)
+* assembly [Aspose.OMR](../../)
+
+<!-- 編集しないでください: xmldocmd によって Aspose.OMR.dll 用に生成されました -->

--- a/japanese/cpp/aspose.omr.cpp/metered/getconsumptioncredit/_index.md
+++ b/japanese/cpp/aspose.omr.cpp/metered/getconsumptioncredit/_index.md
@@ -1,0 +1,27 @@
+---
+title: "GetConsumptionCredit"
+second_title: ".NET 用 Aspose.OMR API リファレンス"
+description: "消費クレジットを取得します。"
+type: docs
+weight: 30
+url: /ja/net/aspose.omr/metered/getconsumptioncredit/
+---
+## Metered.GetConsumptionCredit method
+
+消費クレジットを取得します。
+
+```csharp
+public static decimal GetConsumptionCredit()
+```
+
+### 戻り値
+
+消費量
+
+### 参照
+
+* class [Metered](../../metered)
+* namespace [Aspose.OMR](../../metered)
+* assembly [Aspose.OMR](../../../)
+
+<!-- 編集しないでください: xmldocmd によって Aspose.OMR.dll 用に生成されました -->

--- a/japanese/cpp/aspose.omr.cpp/metered/getconsumptionquantity/_index.md
+++ b/japanese/cpp/aspose.omr.cpp/metered/getconsumptionquantity/_index.md
@@ -1,0 +1,27 @@
+---
+title: "GetConsumptionQuantity"
+second_title: ".NET 用 Aspose.OMR API リファレンス"
+description: "消費ファイルサイズを取得します。"
+type: docs
+weight: 40
+url: /ja/net/aspose.omr/metered/getconsumptionquantity/
+---
+## Metered.GetConsumptionQuantity method
+
+消費ファイルサイズを取得します。
+
+```csharp
+public static decimal GetConsumptionQuantity()
+```
+
+### 戻り値
+
+消費量
+
+### 参照
+
+* class [Metered](../../metered)
+* namespace [Aspose.OMR](../../metered)
+* assembly [Aspose.OMR](../../../)
+
+<!-- 編集しないでください: xmldocmd によって Aspose.OMR.dll 用に生成されました -->

--- a/japanese/cpp/aspose.omr.cpp/metered/metered/_index.md
+++ b/japanese/cpp/aspose.omr.cpp/metered/metered/_index.md
@@ -1,0 +1,23 @@
+---
+title: "メーター制"
+second_title: ".NET 用 Aspose.OMR API リファレンス"
+description: "このクラスの新しいインスタンスを初期化します。"
+type: docs
+weight: 10
+url: /ja/net/aspose.omr/metered/metered/
+---
+## Metered constructor
+
+このクラスの新しいインスタンスを初期化します。
+
+```csharp
+public Metered()
+```
+
+### 参照
+
+* class [Metered](../../metered)
+* namespace [Aspose.OMR](../../metered)
+* assembly [Aspose.OMR](../../../)
+
+<!-- 編集しないでください: xmldocmd によって Aspose.OMR.dll 用に生成されました -->

--- a/japanese/cpp/aspose.omr.cpp/metered/setmeteredkey/_index.md
+++ b/japanese/cpp/aspose.omr.cpp/metered/setmeteredkey/_index.md
@@ -1,0 +1,28 @@
+---
+title: "SetMeteredKey"
+second_title: ".NET 用 Aspose.OMR API リファレンス"
+description: "メーター制の公開キーとプライベートキーを設定します。"
+type: docs
+weight: 20
+url: /ja/net/aspose.omr/metered/setmeteredkey/
+---
+## Metered.SetMeteredKey method
+
+メーター制の公開キーとプライベートキーを設定します。
+
+```csharp
+public void SetMeteredKey(string publicKey, string privateKey)
+```
+
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| publicKey | 文字列 | 公開鍵 |
+| privateKey | 文字列 | 秘密鍵 |
+
+### 参照
+
+* class [Metered](../../metered)
+* namespace [Aspose.OMR](../../metered)
+* assembly [Aspose.OMR](../../../)
+
+<!-- 編集しないでください: xmldocmd によって Aspose.OMR.dll 用に生成されました -->


### PR DESCRIPTION
Automated translation of the CPP API Reference to **Japanese** (`ja`) generated by RDA.

- Pages translated: 11/11
- Errors: 0
- Source: `english/cpp`
- Output: `japanese/cpp`

🤖 Generated by RDA