### PR TITLE
[auto] Translate CPP API Reference to Korean

### DIFF
--- a/korean/cpp/_index.md
+++ b/korean/cpp/_index.md
@@ -1,0 +1,15 @@
+---
+title: "Aspose.OMR for C++"
+type: docs
+weight: 10
+url: /ko/cpp/
+keywords: "Aspose.OMR for C++, Aspose OMR, Aspose API Reference."
+description: "Aspose.OMR for C++는 OMR 디지털 시트 이미지에서 광학 마크를 인식하는 API입니다."
+is_root: true
+---
+## 네임스페이스
+
+| 네임스페이스 | 설명 |
+| --- | --- |
+
+<!-- 편집 금지: xmldocmd에 의해 Aspose.OMR.dll용으로 생성됨 -->

--- a/korean/cpp/aspose.omr.cpp/_index.md
+++ b/korean/cpp/aspose.omr.cpp/_index.md
@@ -1,0 +1,18 @@
+---
+title: "Aspose.OMR"
+second_title: "Aspose.OMR for C++ API 레퍼런스"
+description: "Aspose.OMR은 라이선스 메서드를 포함합니다."
+type: docs
+weight: 10
+url: /ko/cpp/aspose.omr/
+---
+**Aspose.OMR**은 라이선스 메서드를 포함합니다.
+
+## 클래스
+
+| 클래스 | 설명 |
+| --- | --- |
+| [License](./license) | 구성 요소에 라이선스를 부여하는 메서드를 제공합니다. |
+| [Metered](./metered) | 계량 키를 설정하는 메서드를 제공합니다. |
+
+<!-- 편집 금지: xmldocmd에 의해 Aspose.OMR.dll용으로 생성됨 -->

--- a/korean/cpp/aspose.omr.cpp/license/_index.md
+++ b/korean/cpp/aspose.omr.cpp/license/_index.md
@@ -1,0 +1,58 @@
+---
+title: "라이선스"
+second_title: "Aspose.OMR for .NET API 레퍼런스"
+description: "구성 요소에 라이선스를 부여하는 메서드를 제공합니다."
+type: docs
+weight: 20
+url: /ko/net/aspose.omr/license/
+---
+## License class
+
+구성 요소에 라이선스를 부여하는 메서드를 제공합니다.
+
+```csharp
+public class License
+```
+
+## 생성자
+
+| 이름 | 설명 |
+| --- | --- |
+| [License](license)() | 이 클래스의 새 인스턴스를 초기화합니다. |
+
+## 속성
+
+| 이름 | 설명 |
+| --- | --- |
+| [Embedded](../../aspose.omr/license/embedded) { get; set; } | 라이선스 번호가 포함된 리소스로 추가되었습니다. |
+
+## 메서드
+
+| 이름 | 설명 |
+| --- | --- |
+| [SetLicense](../../aspose.omr/license/setlicense#setlicense)(Stream) | 구성 요소에 라이선스를 적용합니다. |
+| [SetLicense](../../aspose.omr/license/setlicense#setlicense_1)(string) | 구성 요소에 라이선스를 적용합니다. |
+
+### 예제
+
+이 예제에서는 구성 요소가 포함된 폴더, 호출 어셈블리가 포함된 폴더, 진입 어셈블리의 폴더에서 MyLicense.lic 라는 라이선스 파일을 찾은 다음 호출 어셈블리의 포함된 리소스에서 찾으려고 시도합니다.
+
+```csharp
+[C#]
+
+License license = new License();
+license.SetLicense("MyLicense.lic");
+
+
+[Visual Basic]
+
+Dim license As license = New license
+License.SetLicense("MyLicense.lic")
+```
+
+### 참고
+
+* namespace [Aspose.OMR](../../aspose.omr)
+* assembly [Aspose.OMR](../../)
+
+<!-- 편집 금지: xmldocmd에 의해 Aspose.OMR.dll용으로 생성됨 -->

--- a/korean/cpp/aspose.omr.cpp/license/embedded/_index.md
+++ b/korean/cpp/aspose.omr.cpp/license/embedded/_index.md
@@ -1,0 +1,23 @@
+---
+title: "임베디드"
+second_title: "Aspose.OMR for .NET API 레퍼런스"
+description: "라이선스 번호가 포함된 리소스로 추가되었습니다."
+type: docs
+weight: 20
+url: /ko/net/aspose.omr/license/embedded/
+---
+## License.Embedded property
+
+라이선스 번호가 포함된 리소스로 추가되었습니다.
+
+```csharp
+public bool Embedded { get; set; }
+```
+
+### 참고
+
+* class [License](../../license)
+* namespace [Aspose.OMR](../../license)
+* assembly [Aspose.OMR](../../../)
+
+<!-- 편집 금지: xmldocmd에 의해 Aspose.OMR.dll용으로 생성됨 -->

--- a/korean/cpp/aspose.omr.cpp/license/license/_index.md
+++ b/korean/cpp/aspose.omr.cpp/license/license/_index.md
@@ -1,0 +1,40 @@
+---
+title: "라이선스"
+second_title: "Aspose.OMR for .NET API 레퍼런스"
+description: "이 클래스의 새 인스턴스를 초기화합니다."
+type: docs
+weight: 10
+url: /ko/net/aspose.omr/license/license/
+---
+## License constructor
+
+이 클래스의 새 인스턴스를 초기화합니다.
+
+```csharp
+public License()
+```
+
+### 예제
+
+이 예제에서는 구성 요소가 포함된 폴더, 호출 어셈블리가 포함된 폴더, 진입 어셈블리의 폴더에서 MyLicense.lic 라는 라이선스 파일을 찾은 다음 호출 어셈블리의 포함된 리소스에서 찾으려고 시도합니다.
+
+```csharp
+[C#]
+
+License license = new License();
+license.SetLicense("MyLicense.lic");
+
+
+[Visual Basic]
+
+Dim license As license = New license
+License.SetLicense("MyLicense.lic")
+```
+
+### 참고
+
+* class [License](../../license)
+* namespace [Aspose.OMR](../../license)
+* assembly [Aspose.OMR](../../../)
+
+<!-- 편집 금지: xmldocmd에 의해 Aspose.OMR.dll용으로 생성됨 -->

--- a/korean/cpp/aspose.omr.cpp/license/setlicense/_index.md
+++ b/korean/cpp/aspose.omr.cpp/license/setlicense/_index.md
@@ -1,0 +1,101 @@
+---
+title: "SetLicense"
+second_title: "Aspose.OMR for .NET API 레퍼런스"
+description: "구성 요소에 라이선스를 적용합니다."
+type: docs
+weight: 30
+url: /ko/net/aspose.omr/license/setlicense/
+---
+## SetLicense(string) {#setlicense_1}
+
+구성 요소에 라이선스를 적용합니다.
+
+```csharp
+public void SetLicense(string licenseName)
+```
+
+### 비고
+
+다음 위치에서 라이선스를 찾으려고 시도합니다:
+
+1. 명시적 경로.
+
+2. Aspose 구성 요소 어셈블리가 포함된 폴더.
+
+3. 클라이언트의 호출 어셈블리가 포함된 폴더.
+
+4. 항목(시작) 어셈블리를 포함하는 폴더.
+
+5. 클라이언트의 호출 어셈블리에 포함된 임베디드 리소스.
+
+**Note:**On the .NET Compact Framework, tries to find the license only in these locations:
+
+1. 명시적 경로.
+
+2. 클라이언트의 호출 어셈블리에 포함된 임베디드 리소스.
+
+### 예제
+
+이 예제에서는 구성 요소가 포함된 폴더, 호출 어셈블리가 포함된 폴더, 진입 어셈블리의 폴더에서 MyLicense.lic 라는 라이선스 파일을 찾은 다음 호출 어셈블리의 포함된 리소스에서 찾으려고 시도합니다.
+
+```csharp
+[C#]
+
+License license = new License();
+license.SetLicense("MyLicense.lic");
+
+
+[Visual Basic]
+
+Dim license As License = New License
+license.SetLicense("MyLicense.lic")
+```
+
+전체 파일 이름이거나 짧은 파일 이름, 혹은 임베디드 리소스 이름일 수 있습니다. 빈 문자열을 사용하면 평가 모드로 전환됩니다.
+
+### 참고
+
+* class [License](../../license)
+* namespace [Aspose.OMR](../../license)
+* assembly [Aspose.OMR](../../../)
+
+---
+
+## SetLicense(Stream) {#setlicense}
+
+구성 요소에 라이선스를 적용합니다.
+
+```csharp
+public void SetLicense(Stream stream)
+```
+
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| 스트림 | Stream | 라이선스를 포함하는 스트림. |
+
+### 비고
+
+스트림에서 라이선스를 로드하려면 이 메서드를 사용하십시오.
+
+### 예제
+
+```csharp
+[C#]
+
+License license = new License();
+license.SetLicense(myStream);
+
+
+[Visual Basic]
+
+Dim license as License = new License
+license.SetLicense(myStream)
+```
+
+### 참고
+
+* class [License](../../license)
+* namespace [Aspose.OMR](../../license)
+* assembly [Aspose.OMR](../../../)
+
+<!-- 편집 금지: xmldocmd에 의해 Aspose.OMR.dll용으로 생성됨 -->

--- a/korean/cpp/aspose.omr.cpp/metered/_index.md
+++ b/korean/cpp/aspose.omr.cpp/metered/_index.md
@@ -1,0 +1,60 @@
+---
+title: "계량"
+second_title: "Aspose.OMR for .NET API 레퍼런스"
+description: "계량 키를 설정하는 메서드를 제공합니다."
+type: docs
+weight: 10
+url: /ko/net/aspose.omr/metered/
+---
+## Metered class
+
+계량 키를 설정하는 메서드를 제공합니다.
+
+```csharp
+public class Metered
+```
+
+## 생성자
+
+| 이름 | 설명 |
+| --- | --- |
+| [Metered](metered)() | 이 클래스의 새 인스턴스를 초기화합니다. |
+
+## 메서드
+
+| 이름 | 설명 |
+| --- | --- |
+| [SetMeteredKey](../../aspose.omr/metered/setmeteredkey)(string, string) | 계량 공개 및 개인 키를 설정합니다 |
+| static [GetConsumptionCredit](../../aspose.omr/metered/getconsumptioncredit)() | 소비 크레딧을 가져옵니다 |
+| static [GetConsumptionQuantity](../../aspose.omr/metered/getconsumptionquantity)() | 소비 파일 크기를 가져옵니다 |
+
+### 예제
+
+이 예제에서는 계량 공개 및 개인 키를 설정하려고 시도합니다.
+
+```csharp
+[C#]
+
+Metered matered = new Metered();
+matered.SetMeteredKey("PublicKey", "PrivateKey");
+
+
+[Visual Basic]
+
+Dim matered As Metered = New Metered
+matered.SetMeteredKey("PublicKey", "PrivateKey")
+```
+
+구성 요소 jar 파일:
+
+```csharp
+Metered matered = new Metered();
+matered.setMeteredKey("PublicKey", "PrivateKey");
+```
+
+### 참고
+
+* namespace [Aspose.OMR](../../aspose.omr)
+* assembly [Aspose.OMR](../../)
+
+<!-- 편집 금지: xmldocmd에 의해 Aspose.OMR.dll용으로 생성됨 -->

--- a/korean/cpp/aspose.omr.cpp/metered/getconsumptioncredit/_index.md
+++ b/korean/cpp/aspose.omr.cpp/metered/getconsumptioncredit/_index.md
@@ -1,0 +1,27 @@
+---
+title: "GetConsumptionCredit"
+second_title: "Aspose.OMR for .NET API 레퍼런스"
+description: "소비 크레딧을 가져옵니다"
+type: docs
+weight: 30
+url: /ko/net/aspose.omr/metered/getconsumptioncredit/
+---
+## Metered.GetConsumptionCredit method
+
+소비 크레딧을 가져옵니다
+
+```csharp
+public static decimal GetConsumptionCredit()
+```
+
+### 반환 값
+
+소비량
+
+### 참고
+
+* class [Metered](../../metered)
+* namespace [Aspose.OMR](../../metered)
+* assembly [Aspose.OMR](../../../)
+
+<!-- 편집 금지: xmldocmd에 의해 Aspose.OMR.dll용으로 생성됨 -->

--- a/korean/cpp/aspose.omr.cpp/metered/getconsumptionquantity/_index.md
+++ b/korean/cpp/aspose.omr.cpp/metered/getconsumptionquantity/_index.md
@@ -1,0 +1,27 @@
+---
+title: "GetConsumptionQuantity"
+second_title: "Aspose.OMR for .NET API 레퍼런스"
+description: "소비 파일 크기를 가져옵니다"
+type: docs
+weight: 40
+url: /ko/net/aspose.omr/metered/getconsumptionquantity/
+---
+## Metered.GetConsumptionQuantity method
+
+소비 파일 크기를 가져옵니다
+
+```csharp
+public static decimal GetConsumptionQuantity()
+```
+
+### 반환 값
+
+소비량
+
+### 참고
+
+* class [Metered](../../metered)
+* namespace [Aspose.OMR](../../metered)
+* assembly [Aspose.OMR](../../../)
+
+<!-- 편집 금지: xmldocmd에 의해 Aspose.OMR.dll용으로 생성됨 -->

--- a/korean/cpp/aspose.omr.cpp/metered/metered/_index.md
+++ b/korean/cpp/aspose.omr.cpp/metered/metered/_index.md
@@ -1,0 +1,23 @@
+---
+title: "계량"
+second_title: "Aspose.OMR for .NET API 레퍼런스"
+description: "이 클래스의 새 인스턴스를 초기화합니다."
+type: docs
+weight: 10
+url: /ko/net/aspose.omr/metered/metered/
+---
+## Metered constructor
+
+이 클래스의 새 인스턴스를 초기화합니다.
+
+```csharp
+public Metered()
+```
+
+### 참고
+
+* class [Metered](../../metered)
+* namespace [Aspose.OMR](../../metered)
+* assembly [Aspose.OMR](../../../)
+
+<!-- 편집 금지: xmldocmd에 의해 Aspose.OMR.dll용으로 생성됨 -->

--- a/korean/cpp/aspose.omr.cpp/metered/setmeteredkey/_index.md
+++ b/korean/cpp/aspose.omr.cpp/metered/setmeteredkey/_index.md
@@ -1,0 +1,28 @@
+---
+title: "SetMeteredKey"
+second_title: "Aspose.OMR for .NET API 레퍼런스"
+description: "계량 공개 및 개인 키를 설정합니다"
+type: docs
+weight: 20
+url: /ko/net/aspose.omr/metered/setmeteredkey/
+---
+## Metered.SetMeteredKey method
+
+계량 공개 및 개인 키를 설정합니다
+
+```csharp
+public void SetMeteredKey(string publicKey, string privateKey)
+```
+
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| publicKey | 문자열 | 공개 키 |
+| privateKey | 문자열 | 개인 키 |
+
+### 참고
+
+* class [Metered](../../metered)
+* namespace [Aspose.OMR](../../metered)
+* assembly [Aspose.OMR](../../../)
+
+<!-- 편집 금지: xmldocmd에 의해 Aspose.OMR.dll용으로 생성됨 -->


### PR DESCRIPTION
Automated translation of the CPP API Reference to **Korean** (`ko`) generated by RDA.

- Pages translated: 11/11
- Errors: 0
- Source: `english/cpp`
- Output: `korean/cpp`

🤖 Generated by RDA