### PR TITLE
[auto] Translate CPP API Reference to Netherlands

### DIFF
--- a/netherlands/cpp/_index.md
+++ b/netherlands/cpp/_index.md
@@ -1,0 +1,15 @@
+---
+title: "Aspose.OMR for C++"
+type: docs
+weight: 10
+url: /nl/cpp/
+keywords: "Aspose.OMR for C++, Aspose OMR, Aspose API Reference."
+description: "Aspose.OMR for C++ is een API om optische markeringen te herkennen van OMR-gedigitaliseerde bladafbeeldingen."
+is_root: true
+---
+## Naamruimtes
+
+| Naamruimte | Beschrijving |
+| --- | --- |
+
+<!-- NIET BEWERKEN: gegenereerd door xmldocmd voor Aspose.OMR.dll -->

--- a/netherlands/cpp/aspose.omr.cpp/_index.md
+++ b/netherlands/cpp/aspose.omr.cpp/_index.md
@@ -1,0 +1,18 @@
+---
+title: "Aspose.OMR"
+second_title: "Aspose.OMR for C++ API-referentie"
+description: "De Aspose.OMR bevat licentiemethoden."
+type: docs
+weight: 10
+url: /nl/cpp/aspose.omr/
+---
+De **Aspose.OMR** bevat licentiemethoden.
+
+## Klassen
+
+| Klasse | Beschrijving |
+| --- | --- |
+| [License](./license) | Biedt methoden om het component te licentiëren. |
+| [Metered](./metered) | Biedt methoden om de metered key in te stellen. |
+
+<!-- NIET BEWERKEN: gegenereerd door xmldocmd voor Aspose.OMR.dll -->

--- a/netherlands/cpp/aspose.omr.cpp/license/_index.md
+++ b/netherlands/cpp/aspose.omr.cpp/license/_index.md
@@ -1,0 +1,58 @@
+---
+title: "Licentie"
+second_title: "Aspose.OMR for .NET API-referentie"
+description: "Biedt methoden om het component te licentiëren."
+type: docs
+weight: 20
+url: /nl/net/aspose.omr/license/
+---
+## License class
+
+Biedt methoden om het component te licentiëren.
+
+```csharp
+public class License
+```
+
+## Constructors
+
+| Naam | Beschrijving |
+| --- | --- |
+| [License](license)() | Initialiseert een nieuw exemplaar van deze klasse. |
+
+## Eigenschappen
+
+| Naam | Beschrijving |
+| --- | --- |
+| [Embedded](../../aspose.omr/license/embedded) { get; set; } | Licentienummer is toegevoegd als ingebedde resource. |
+
+## Methoden
+
+| Naam | Beschrijving |
+| --- | --- |
+| [SetLicense](../../aspose.omr/license/setlicense#setlicense)(Stream) | Licentieert het component. |
+| [SetLicense](../../aspose.omr/license/setlicense#setlicense_1)(string) | Licentieert het component. |
+
+### Voorbeelden
+
+In dit voorbeeld wordt geprobeerd een licentiebestand met de naam MyLicense.lic te vinden in de map die het component bevat, in de map die de aanroepende assembly bevat, in de map van de entry‑assembly en vervolgens in de ingebedde resources van de aanroepende assembly.
+
+```csharp
+[C#]
+
+License license = new License();
+license.SetLicense("MyLicense.lic");
+
+
+[Visual Basic]
+
+Dim license As license = New license
+License.SetLicense("MyLicense.lic")
+```
+
+### Zie ook
+
+* namespace [Aspose.OMR](../../aspose.omr)
+* assembly [Aspose.OMR](../../)
+
+<!-- NIET BEWERKEN: gegenereerd door xmldocmd voor Aspose.OMR.dll -->

--- a/netherlands/cpp/aspose.omr.cpp/license/embedded/_index.md
+++ b/netherlands/cpp/aspose.omr.cpp/license/embedded/_index.md
@@ -1,0 +1,23 @@
+---
+title: "Ingebed"
+second_title: "Aspose.OMR for .NET API-referentie"
+description: "Licentienummer is toegevoegd als ingebedde resource."
+type: docs
+weight: 20
+url: /nl/net/aspose.omr/license/embedded/
+---
+## License.Embedded property
+
+Licentienummer is toegevoegd als ingebedde resource.
+
+```csharp
+public bool Embedded { get; set; }
+```
+
+### Zie ook
+
+* class [License](../../license)
+* namespace [Aspose.OMR](../../license)
+* assembly [Aspose.OMR](../../../)
+
+<!-- NIET BEWERKEN: gegenereerd door xmldocmd voor Aspose.OMR.dll -->

--- a/netherlands/cpp/aspose.omr.cpp/license/license/_index.md
+++ b/netherlands/cpp/aspose.omr.cpp/license/license/_index.md
@@ -1,0 +1,40 @@
+---
+title: "Licentie"
+second_title: "Aspose.OMR for .NET API-referentie"
+description: "Initialiseert een nieuw exemplaar van deze klasse."
+type: docs
+weight: 10
+url: /nl/net/aspose.omr/license/license/
+---
+## License constructor
+
+Initialiseert een nieuw exemplaar van deze klasse.
+
+```csharp
+public License()
+```
+
+### Voorbeelden
+
+In dit voorbeeld wordt geprobeerd een licentiebestand met de naam MyLicense.lic te vinden in de map die het component bevat, in de map die de aanroepende assembly bevat, in de map van de entry‑assembly en vervolgens in de ingebedde resources van de aanroepende assembly.
+
+```csharp
+[C#]
+
+License license = new License();
+license.SetLicense("MyLicense.lic");
+
+
+[Visual Basic]
+
+Dim license As license = New license
+License.SetLicense("MyLicense.lic")
+```
+
+### Zie ook
+
+* class [License](../../license)
+* namespace [Aspose.OMR](../../license)
+* assembly [Aspose.OMR](../../../)
+
+<!-- NIET BEWERKEN: gegenereerd door xmldocmd voor Aspose.OMR.dll -->

--- a/netherlands/cpp/aspose.omr.cpp/license/setlicense/_index.md
+++ b/netherlands/cpp/aspose.omr.cpp/license/setlicense/_index.md
@@ -1,0 +1,101 @@
+---
+title: "SetLicense"
+second_title: "Aspose.OMR for .NET API-referentie"
+description: "Licentieert het component."
+type: docs
+weight: 30
+url: /nl/net/aspose.omr/license/setlicense/
+---
+## SetLicense(string) {#setlicense_1}
+
+Licentieert het component.
+
+```csharp
+public void SetLicense(string licenseName)
+```
+
+### Opmerkingen
+
+Probeert de licentie te vinden op de volgende locaties:
+
+1. Expliciet pad.
+
+2. De map die de Aspose‑component‑assembly bevat.
+
+3. De map die de aanroepende assembly van de client bevat.
+
+4. De map die de entry (startup) assembly bevat.
+
+5. Een ingebedde resource in de aanroepende assembly van de client.
+
+**Note:**On the .NET Compact Framework, tries to find the license only in these locations:
+
+1. Expliciet pad.
+
+2. Een ingebedde resource in de aanroepende assembly van de client.
+
+### Voorbeelden
+
+In dit voorbeeld wordt geprobeerd een licentiebestand met de naam MyLicense.lic te vinden in de map die het component bevat, in de map die de aanroepende assembly bevat, in de map van de entry‑assembly en vervolgens in de ingebedde resources van de aanroepende assembly.
+
+```csharp
+[C#]
+
+License license = new License();
+license.SetLicense("MyLicense.lic");
+
+
+[Visual Basic]
+
+Dim license As License = New License
+license.SetLicense("MyLicense.lic")
+```
+
+Kan een volledige of korte bestandsnaam of de naam van een ingebedde resource zijn. Gebruik een lege string om over te schakelen naar evaluatiemodus.
+
+### Zie ook
+
+* class [License](../../license)
+* namespace [Aspose.OMR](../../license)
+* assembly [Aspose.OMR](../../../)
+
+---
+
+## SetLicense(Stream) {#setlicense}
+
+Licentieert het component.
+
+```csharp
+public void SetLicense(Stream stream)
+```
+
+| Parameter | Type | Beschrijving |
+| --- | --- | --- |
+| stream | Stream | Een stream die de licentie bevat. |
+
+### Opmerkingen
+
+Gebruik deze methode om een licentie uit een stream te laden.
+
+### Voorbeelden
+
+```csharp
+[C#]
+
+License license = new License();
+license.SetLicense(myStream);
+
+
+[Visual Basic]
+
+Dim license as License = new License
+license.SetLicense(myStream)
+```
+
+### Zie ook
+
+* class [License](../../license)
+* namespace [Aspose.OMR](../../license)
+* assembly [Aspose.OMR](../../../)
+
+<!-- NIET BEWERKEN: gegenereerd door xmldocmd voor Aspose.OMR.dll -->

--- a/netherlands/cpp/aspose.omr.cpp/metered/_index.md
+++ b/netherlands/cpp/aspose.omr.cpp/metered/_index.md
@@ -1,0 +1,60 @@
+---
+title: "Metered"
+second_title: "Aspose.OMR for .NET API-referentie"
+description: "Biedt methoden om de metered key in te stellen."
+type: docs
+weight: 10
+url: /nl/net/aspose.omr/metered/
+---
+## Metered class
+
+Biedt methoden om de metered key in te stellen.
+
+```csharp
+public class Metered
+```
+
+## Constructors
+
+| Naam | Beschrijving |
+| --- | --- |
+| [Metered](metered)() | Initialiseert een nieuw exemplaar van deze klasse. |
+
+## Methoden
+
+| Naam | Beschrijving |
+| --- | --- |
+| [SetMeteredKey](../../aspose.omr/metered/setmeteredkey)(string, string) | Stelt metered publieke en private sleutel in |
+| static [GetConsumptionCredit](../../aspose.omr/metered/getconsumptioncredit)() | Haalt consumptietegoed op |
+| static [GetConsumptionQuantity](../../aspose.omr/metered/getconsumptionquantity)() | Haalt consumptiebestandsgrootte op |
+
+### Voorbeelden
+
+In dit voorbeeld wordt geprobeerd de metered publieke en private sleutel in te stellen.
+
+```csharp
+[C#]
+
+Metered matered = new Metered();
+matered.SetMeteredKey("PublicKey", "PrivateKey");
+
+
+[Visual Basic]
+
+Dim matered As Metered = New Metered
+matered.SetMeteredKey("PublicKey", "PrivateKey")
+```
+
+het component‑jar‑bestand:
+
+```csharp
+Metered matered = new Metered();
+matered.setMeteredKey("PublicKey", "PrivateKey");
+```
+
+### Zie ook
+
+* namespace [Aspose.OMR](../../aspose.omr)
+* assembly [Aspose.OMR](../../)
+
+<!-- NIET BEWERKEN: gegenereerd door xmldocmd voor Aspose.OMR.dll -->

--- a/netherlands/cpp/aspose.omr.cpp/metered/getconsumptioncredit/_index.md
+++ b/netherlands/cpp/aspose.omr.cpp/metered/getconsumptioncredit/_index.md
@@ -1,0 +1,27 @@
+---
+title: "GetConsumptionCredit"
+second_title: "Aspose.OMR for .NET API-referentie"
+description: "Haalt consumptietegoed op"
+type: docs
+weight: 30
+url: /nl/net/aspose.omr/metered/getconsumptioncredit/
+---
+## Metered.GetConsumptionCredit method
+
+Haalt consumptietegoed op
+
+```csharp
+public static decimal GetConsumptionCredit()
+```
+
+### Retourwaarde
+
+verbruikshoeveelheid
+
+### Zie ook
+
+* class [Metered](../../metered)
+* namespace [Aspose.OMR](../../metered)
+* assembly [Aspose.OMR](../../../)
+
+<!-- NIET BEWERKEN: gegenereerd door xmldocmd voor Aspose.OMR.dll -->

--- a/netherlands/cpp/aspose.omr.cpp/metered/getconsumptionquantity/_index.md
+++ b/netherlands/cpp/aspose.omr.cpp/metered/getconsumptionquantity/_index.md
@@ -1,0 +1,27 @@
+---
+title: "GetConsumptionQuantity"
+second_title: "Aspose.OMR for .NET API-referentie"
+description: "Haalt consumptiebestandsgrootte op"
+type: docs
+weight: 40
+url: /nl/net/aspose.omr/metered/getconsumptionquantity/
+---
+## Metered.GetConsumptionQuantity method
+
+Haalt consumptiebestandsgrootte op
+
+```csharp
+public static decimal GetConsumptionQuantity()
+```
+
+### Retourwaarde
+
+verbruikshoeveelheid
+
+### Zie ook
+
+* class [Metered](../../metered)
+* namespace [Aspose.OMR](../../metered)
+* assembly [Aspose.OMR](../../../)
+
+<!-- NIET BEWERKEN: gegenereerd door xmldocmd voor Aspose.OMR.dll -->

--- a/netherlands/cpp/aspose.omr.cpp/metered/metered/_index.md
+++ b/netherlands/cpp/aspose.omr.cpp/metered/metered/_index.md
@@ -1,0 +1,23 @@
+---
+title: "Metered"
+second_title: "Aspose.OMR for .NET API-referentie"
+description: "Initialiseert een nieuw exemplaar van deze klasse."
+type: docs
+weight: 10
+url: /nl/net/aspose.omr/metered/metered/
+---
+## Metered constructor
+
+Initialiseert een nieuw exemplaar van deze klasse.
+
+```csharp
+public Metered()
+```
+
+### Zie ook
+
+* class [Metered](../../metered)
+* namespace [Aspose.OMR](../../metered)
+* assembly [Aspose.OMR](../../../)
+
+<!-- NIET BEWERKEN: gegenereerd door xmldocmd voor Aspose.OMR.dll -->

--- a/netherlands/cpp/aspose.omr.cpp/metered/setmeteredkey/_index.md
+++ b/netherlands/cpp/aspose.omr.cpp/metered/setmeteredkey/_index.md
@@ -1,0 +1,28 @@
+---
+title: "SetMeteredKey"
+second_title: "Aspose.OMR for .NET API-referentie"
+description: "Stelt metered publieke en private sleutel in"
+type: docs
+weight: 20
+url: /nl/net/aspose.omr/metered/setmeteredkey/
+---
+## Metered.SetMeteredKey method
+
+Stelt metered publieke en private sleutel in
+
+```csharp
+public void SetMeteredKey(string publicKey, string privateKey)
+```
+
+| Parameter | Type | Beschrijving |
+| --- | --- | --- |
+| publicKey | String | publieke sleutel |
+| privateKey | String | privésleutel |
+
+### Zie ook
+
+* class [Metered](../../metered)
+* namespace [Aspose.OMR](../../metered)
+* assembly [Aspose.OMR](../../../)
+
+<!-- NIET BEWERKEN: gegenereerd door xmldocmd voor Aspose.OMR.dll -->


### PR DESCRIPTION
Automated translation of the CPP API Reference to **Netherlands** (`nl`) generated by RDA.

- Pages translated: 11/11
- Errors: 0
- Source: `english/cpp`
- Output: `netherlands/cpp`

🤖 Generated by RDA