### PR TITLE
[auto] Translate CPP API Reference to Russian

### DIFF
--- a/russian/cpp/_index.md
+++ b/russian/cpp/_index.md
@@ -1,0 +1,15 @@
+---
+title: "Aspose.OMR для C++"
+type: docs
+weight: 10
+url: /ru/cpp/
+keywords: "Aspose.OMR for C++, Aspose OMR, Aspose API Reference."
+description: "Aspose.OMR для C++ — это API для распознавания оптических меток на оцифрованных листовых изображениях OMR."
+is_root: true
+---
+## Пространства имён
+
+| Пространство имён | Описание |
+| --- | --- |
+
+<!-- НЕ РЕДАКТИРОВАТЬ: сгенерировано xmldocmd для Aspose.OMR.dll -->

--- a/russian/cpp/aspose.omr.cpp/_index.md
+++ b/russian/cpp/aspose.omr.cpp/_index.md
@@ -1,0 +1,18 @@
+---
+title: "Aspose.OMR"
+second_title: "Справочник API Aspose.OMR для C++"
+description: "Aspose.OMR содержит методы лицензирования."
+type: docs
+weight: 10
+url: /ru/cpp/aspose.omr/
+---
+В **Aspose.OMR** содержатся методы лицензирования.
+
+## Классы
+
+| Класс | Описание |
+| --- | --- |
+| [License](./license) | Предоставляет методы лицензирования компонента. |
+| [Metered](./metered) | Предоставляет методы установки ключа с учётом использования. |
+
+<!-- НЕ РЕДАКТИРОВАТЬ: сгенерировано xmldocmd для Aspose.OMR.dll -->

--- a/russian/cpp/aspose.omr.cpp/license/_index.md
+++ b/russian/cpp/aspose.omr.cpp/license/_index.md
@@ -1,0 +1,58 @@
+---
+title: "Лицензия"
+second_title: "Справочник API Aspose.OMR для .NET"
+description: "Предоставляет методы лицензирования компонента."
+type: docs
+weight: 20
+url: /ru/net/aspose.omr/license/
+---
+## License class
+
+Предоставляет методы лицензирования компонента.
+
+```csharp
+public class License
+```
+
+## Конструкторы
+
+| Имя | Описание |
+| --- | --- |
+| [License](license)() | Инициализирует новый экземпляр этого класса. |
+
+## Свойства
+
+| Имя | Описание |
+| --- | --- |
+| [Embedded](../../aspose.omr/license/embedded) { get; set; } | Номер лицензии был добавлен как встроенный ресурс. |
+
+## Методы
+
+| Имя | Описание |
+| --- | --- |
+| [SetLicense](../../aspose.omr/license/setlicense#setlicense)(Stream) | Лицензирует компонент. |
+| [SetLicense](../../aspose.omr/license/setlicense#setlicense_1)(string) | Лицензирует компонент. |
+
+### Примеры
+
+В этом примере будет предпринята попытка найти файл лицензии с именем MyLicense.lic в папке, содержащей компонент, в папке, содержащей вызывающую сборку, в папке входной сборки, а затем во встроенных ресурсах вызывающей сборки.
+
+```csharp
+[C#]
+
+License license = new License();
+license.SetLicense("MyLicense.lic");
+
+
+[Visual Basic]
+
+Dim license As license = New license
+License.SetLicense("MyLicense.lic")
+```
+
+### См. также
+
+* namespace [Aspose.OMR](../../aspose.omr)
+* assembly [Aspose.OMR](../../)
+
+<!-- НЕ РЕДАКТИРОВАТЬ: сгенерировано xmldocmd для Aspose.OMR.dll -->

--- a/russian/cpp/aspose.omr.cpp/license/embedded/_index.md
+++ b/russian/cpp/aspose.omr.cpp/license/embedded/_index.md
@@ -1,0 +1,23 @@
+---
+title: "Встроенный"
+second_title: "Справочник API Aspose.OMR для .NET"
+description: "Номер лицензии был добавлен как встроенный ресурс."
+type: docs
+weight: 20
+url: /ru/net/aspose.omr/license/embedded/
+---
+## License.Embedded property
+
+Номер лицензии был добавлен как встроенный ресурс.
+
+```csharp
+public bool Embedded { get; set; }
+```
+
+### См. также
+
+* class [License](../../license)
+* namespace [Aspose.OMR](../../license)
+* assembly [Aspose.OMR](../../../)
+
+<!-- НЕ РЕДАКТИРОВАТЬ: сгенерировано xmldocmd для Aspose.OMR.dll -->

--- a/russian/cpp/aspose.omr.cpp/license/license/_index.md
+++ b/russian/cpp/aspose.omr.cpp/license/license/_index.md
@@ -1,0 +1,40 @@
+---
+title: "Лицензия"
+second_title: "Справочник API Aspose.OMR для .NET"
+description: "Инициализирует новый экземпляр этого класса."
+type: docs
+weight: 10
+url: /ru/net/aspose.omr/license/license/
+---
+## License constructor
+
+Инициализирует новый экземпляр этого класса.
+
+```csharp
+public License()
+```
+
+### Примеры
+
+В этом примере будет предпринята попытка найти файл лицензии с именем MyLicense.lic в папке, содержащей компонент, в папке, содержащей вызывающую сборку, в папке входной сборки, а затем во встроенных ресурсах вызывающей сборки.
+
+```csharp
+[C#]
+
+License license = new License();
+license.SetLicense("MyLicense.lic");
+
+
+[Visual Basic]
+
+Dim license As license = New license
+License.SetLicense("MyLicense.lic")
+```
+
+### См. также
+
+* class [License](../../license)
+* namespace [Aspose.OMR](../../license)
+* assembly [Aspose.OMR](../../../)
+
+<!-- НЕ РЕДАКТИРОВАТЬ: сгенерировано xmldocmd для Aspose.OMR.dll -->

--- a/russian/cpp/aspose.omr.cpp/license/setlicense/_index.md
+++ b/russian/cpp/aspose.omr.cpp/license/setlicense/_index.md
@@ -1,0 +1,101 @@
+---
+title: "SetLicense"
+second_title: "Справочник API Aspose.OMR для .NET"
+description: "Лицензирует компонент."
+type: docs
+weight: 30
+url: /ru/net/aspose.omr/license/setlicense/
+---
+## SetLicense(string) {#setlicense_1}
+
+Лицензирует компонент.
+
+```csharp
+public void SetLicense(string licenseName)
+```
+
+### Примечания
+
+Пытается найти лицензию в следующих местах:
+
+1. Явный путь.
+
+2. Папка, содержащая сборку компонента Aspose.
+
+3. Папка, содержащая вызывающую сборку клиента.
+
+4. Папка, содержащая входную (запускную) сборку.
+
+5. Встроенный ресурс в вызывающей сборке клиента.
+
+**Note:**On the .NET Compact Framework, tries to find the license only in these locations:
+
+1. Явный путь.
+
+2. Встроенный ресурс в вызывающей сборке клиента.
+
+### Примеры
+
+В этом примере будет предпринята попытка найти файл лицензии с именем MyLicense.lic в папке, содержащей компонент, в папке, содержащей вызывающую сборку, в папке входной сборки, а затем во встроенных ресурсах вызывающей сборки.
+
+```csharp
+[C#]
+
+License license = new License();
+license.SetLicense("MyLicense.lic");
+
+
+[Visual Basic]
+
+Dim license As License = New License
+license.SetLicense("MyLicense.lic")
+```
+
+Может быть полным или коротким именем файла или именем встроенного ресурса. Используйте пустую строку, чтобы переключиться в режим оценки.
+
+### См. также
+
+* class [License](../../license)
+* namespace [Aspose.OMR](../../license)
+* assembly [Aspose.OMR](../../../)
+
+---
+
+## SetLicense(Stream) {#setlicense}
+
+Лицензирует компонент.
+
+```csharp
+public void SetLicense(Stream stream)
+```
+
+| Параметр | Тип | Описание |
+| --- | --- | --- |
+| поток | Поток | Поток, содержащий лицензию. |
+
+### Примечания
+
+Используйте этот метод для загрузки лицензии из потока.
+
+### Примеры
+
+```csharp
+[C#]
+
+License license = new License();
+license.SetLicense(myStream);
+
+
+[Visual Basic]
+
+Dim license as License = new License
+license.SetLicense(myStream)
+```
+
+### См. также
+
+* class [License](../../license)
+* namespace [Aspose.OMR](../../license)
+* assembly [Aspose.OMR](../../../)
+
+<!-- НЕ РЕДАКТИРОВАТЬ: сгенерировано xmldocmd для Aspose.OMR.dll -->

--- a/russian/cpp/aspose.omr.cpp/metered/_index.md
+++ b/russian/cpp/aspose.omr.cpp/metered/_index.md
@@ -1,0 +1,60 @@
+---
+title: "Измеряемый"
+second_title: "Справочник API Aspose.OMR для .NET"
+description: "Предоставляет методы установки ключа с учётом использования."
+type: docs
+weight: 10
+url: /ru/net/aspose.omr/metered/
+---
+## Metered class
+
+Предоставляет методы установки ключа с учётом использования.
+
+```csharp
+public class Metered
+```
+
+## Конструкторы
+
+| Имя | Описание |
+| --- | --- |
+| [Metered](metered)() | Инициализирует новый экземпляр этого класса. |
+
+## Методы
+
+| Имя | Описание |
+| --- | --- |
+| [SetMeteredKey](../../aspose.omr/metered/setmeteredkey)(string, string) | Устанавливает публичный и приватный ключ с учётом использования |
+| static [GetConsumptionCredit](../../aspose.omr/metered/getconsumptioncredit)() | Получает кредит потребления |
+| static [GetConsumptionQuantity](../../aspose.omr/metered/getconsumptionquantity)() | Получает размер файла потребления |
+
+### Примеры
+
+В этом примере будет предпринята попытка установить публичный и приватный ключ с учётом использования
+
+```csharp
+[C#]
+
+Metered matered = new Metered();
+matered.SetMeteredKey("PublicKey", "PrivateKey");
+
+
+[Visual Basic]
+
+Dim matered As Metered = New Metered
+matered.SetMeteredKey("PublicKey", "PrivateKey")
+```
+
+файл jar компонента:
+
+```csharp
+Metered matered = new Metered();
+matered.setMeteredKey("PublicKey", "PrivateKey");
+```
+
+### См. также
+
+* namespace [Aspose.OMR](../../aspose.omr)
+* assembly [Aspose.OMR](../../)
+
+<!-- НЕ РЕДАКТИРОВАТЬ: сгенерировано xmldocmd для Aspose.OMR.dll -->

--- a/russian/cpp/aspose.omr.cpp/metered/getconsumptioncredit/_index.md
+++ b/russian/cpp/aspose.omr.cpp/metered/getconsumptioncredit/_index.md
@@ -1,0 +1,27 @@
+---
+title: "GetConsumptionCredit"
+second_title: "Справочник API Aspose.OMR для .NET"
+description: "Получает кредит потребления"
+type: docs
+weight: 30
+url: /ru/net/aspose.omr/metered/getconsumptioncredit/
+---
+## Metered.GetConsumptionCredit method
+
+Получает кредит потребления
+
+```csharp
+public static decimal GetConsumptionCredit()
+```
+
+### Возвращаемое значение
+
+количество потребления
+
+### См. также
+
+* class [Metered](../../metered)
+* namespace [Aspose.OMR](../../metered)
+* assembly [Aspose.OMR](../../../)
+
+<!-- НЕ РЕДАКТИРОВАТЬ: сгенерировано xmldocmd для Aspose.OMR.dll -->

--- a/russian/cpp/aspose.omr.cpp/metered/getconsumptionquantity/_index.md
+++ b/russian/cpp/aspose.omr.cpp/metered/getconsumptionquantity/_index.md
@@ -1,0 +1,27 @@
+---
+title: "GetConsumptionQuantity"
+second_title: "Справочник API Aspose.OMR для .NET"
+description: "Получает размер файла потребления"
+type: docs
+weight: 40
+url: /ru/net/aspose.omr/metered/getconsumptionquantity/
+---
+## Metered.GetConsumptionQuantity method
+
+Получает размер файла потребления
+
+```csharp
+public static decimal GetConsumptionQuantity()
+```
+
+### Возвращаемое значение
+
+количество потребления
+
+### См. также
+
+* class [Metered](../../metered)
+* namespace [Aspose.OMR](../../metered)
+* assembly [Aspose.OMR](../../../)
+
+<!-- НЕ РЕДАКТИРОВАТЬ: сгенерировано xmldocmd для Aspose.OMR.dll -->

--- a/russian/cpp/aspose.omr.cpp/metered/metered/_index.md
+++ b/russian/cpp/aspose.omr.cpp/metered/metered/_index.md
@@ -1,0 +1,23 @@
+---
+title: "Измеряемый"
+second_title: "Справочник API Aspose.OMR для .NET"
+description: "Инициализирует новый экземпляр этого класса."
+type: docs
+weight: 10
+url: /ru/net/aspose.omr/metered/metered/
+---
+## Metered constructor
+
+Инициализирует новый экземпляр этого класса.
+
+```csharp
+public Metered()
+```
+
+### См. также
+
+* class [Metered](../../metered)
+* namespace [Aspose.OMR](../../metered)
+* assembly [Aspose.OMR](../../../)
+
+<!-- НЕ РЕДАКТИРОВАТЬ: сгенерировано xmldocmd для Aspose.OMR.dll -->

--- a/russian/cpp/aspose.omr.cpp/metered/setmeteredkey/_index.md
+++ b/russian/cpp/aspose.omr.cpp/metered/setmeteredkey/_index.md
@@ -1,0 +1,28 @@
+---
+title: "SetMeteredKey"
+second_title: "Справочник API Aspose.OMR для .NET"
+description: "Устанавливает публичный и приватный ключ с учётом использования"
+type: docs
+weight: 20
+url: /ru/net/aspose.omr/metered/setmeteredkey/
+---
+## Metered.SetMeteredKey method
+
+Устанавливает публичный и приватный ключ с учётом использования
+
+```csharp
+public void SetMeteredKey(string publicKey, string privateKey)
+```
+
+| Параметр | Тип | Описание |
+| --- | --- | --- |
+| publicKey | String | публичный ключ |
+| privateKey | String | приватный ключ |
+
+### См. также
+
+* class [Metered](../../metered)
+* namespace [Aspose.OMR](../../metered)
+* assembly [Aspose.OMR](../../../)
+
+<!-- НЕ РЕДАКТИРОВАТЬ: сгенерировано xmldocmd для Aspose.OMR.dll -->


### PR DESCRIPTION
Automated translation of the CPP API Reference to **Russian** (`ru`) generated by RDA.

- Pages translated: 11/11
- Errors: 0
- Source: `english/cpp`
- Output: `russian/cpp`

🤖 Generated by RDA