### PR TITLE
[auto] Translate CPP API Reference to Turkish

### DIFF
--- a/turkish/cpp/_index.md
+++ b/turkish/cpp/_index.md
@@ -1,0 +1,15 @@
+---
+title: "Aspose.OMR for C++"
+type: docs
+weight: 10
+url: /tr/cpp/
+keywords: "Aspose.OMR for C++, Aspose OMR, Aspose API Reference."
+description: "Aspose.OMR for C++ optik işaretleri OMR dijitalleştirilmiş sayfa görüntülerinden tanımak için bir API'dir."
+is_root: true
+---
+## Ad alanları
+
+| Ad alanı | Açıklama |
+| --- | --- |
+
+<!-- DÜZENLEMEYİN: xmldocmd tarafından Aspose.OMR.dll için oluşturuldu -->

--- a/turkish/cpp/aspose.omr.cpp/_index.md
+++ b/turkish/cpp/aspose.omr.cpp/_index.md
@@ -1,0 +1,18 @@
+---
+title: "Aspose.OMR"
+second_title: "Aspose.OMR for C++ API Referansı"
+description: "Aspose.OMR, lisanslama yöntemlerini içerir."
+type: docs
+weight: 10
+url: /tr/cpp/aspose.omr/
+---
+**Aspose.OMR**, lisanslama yöntemlerini içerir.
+
+## Sınıflar
+
+| Sınıf | Açıklama |
+| --- | --- |
+| [License](./license) | Bileşeni lisanslamak için yöntemler sağlar. |
+| [Metered](./metered) | Ölçülen anahtarı ayarlamak için yöntemler sağlar. |
+
+<!-- DÜZENLEMEYİN: xmldocmd tarafından Aspose.OMR.dll için oluşturuldu -->

--- a/turkish/cpp/aspose.omr.cpp/license/_index.md
+++ b/turkish/cpp/aspose.omr.cpp/license/_index.md
@@ -1,0 +1,58 @@
+---
+title: "Lisans"
+second_title: "Aspose.OMR for .NET API Referansı"
+description: "Bileşeni lisanslamak için yöntemler sağlar."
+type: docs
+weight: 20
+url: /tr/net/aspose.omr/license/
+---
+## License class
+
+Bileşeni lisanslamak için yöntemler sağlar.
+
+```csharp
+public class License
+```
+
+## Yapıcılar
+
+| Ad | Açıklama |
+| --- | --- |
+| [License](license)() | Bu sınıfın yeni bir örneğini başlatır. |
+
+## Özellikler
+
+| Ad | Açıklama |
+| --- | --- |
+| [Embedded](../../aspose.omr/license/embedded) { get; set; } | Lisans numarası gömülü kaynak olarak eklendi. |
+
+## Yöntemler
+
+| Ad | Açıklama |
+| --- | --- |
+| [SetLicense](../../aspose.omr/license/setlicense#setlicense)(Stream) | Bileşeni lisanslar. |
+| [SetLicense](../../aspose.omr/license/setlicense#setlicense_1)(string) | Bileşeni lisanslar. |
+
+### Örnekler
+
+Bu örnekte, bileşeni içeren klasörde, çağıran derlemeyi içeren klasörde, giriş derlemesinin klasöründe ve ardından çağıran derlemenin gömülü kaynaklarında MyLicense.lic adlı bir lisans dosyası bulmaya çalışılacaktır.
+
+```csharp
+[C#]
+
+License license = new License();
+license.SetLicense("MyLicense.lic");
+
+
+[Visual Basic]
+
+Dim license As license = New license
+License.SetLicense("MyLicense.lic")
+```
+
+### Ayrıca Bakınız
+
+* namespace [Aspose.OMR](../../aspose.omr)
+* assembly [Aspose.OMR](../../)
+
+<!-- DÜZENLEMEYİN: xmldocmd tarafından Aspose.OMR.dll için oluşturuldu -->

--- a/turkish/cpp/aspose.omr.cpp/license/embedded/_index.md
+++ b/turkish/cpp/aspose.omr.cpp/license/embedded/_index.md
@@ -1,0 +1,23 @@
+---
+title: "Gömülü"
+second_title: "Aspose.OMR for .NET API Referansı"
+description: "Lisans numarası gömülü kaynak olarak eklendi."
+type: docs
+weight: 20
+url: /tr/net/aspose.omr/license/embedded/
+---
+## License.Embedded property
+
+Lisans numarası gömülü kaynak olarak eklendi.
+
+```csharp
+public bool Embedded { get; set; }
+```
+
+### Ayrıca Bakınız
+
+* class [License](../../license)
+* namespace [Aspose.OMR](../../license)
+* assembly [Aspose.OMR](../../../)
+
+<!-- DÜZENLEMEYİN: xmldocmd tarafından Aspose.OMR.dll için oluşturuldu -->

--- a/turkish/cpp/aspose.omr.cpp/license/license/_index.md
+++ b/turkish/cpp/aspose.omr.cpp/license/license/_index.md
@@ -1,0 +1,40 @@
+---
+title: "Lisans"
+second_title: "Aspose.OMR for .NET API Referansı"
+description: "Bu sınıfın yeni bir örneğini başlatır."
+type: docs
+weight: 10
+url: /tr/net/aspose.omr/license/license/
+---
+## License constructor
+
+Bu sınıfın yeni bir örneğini başlatır.
+
+```csharp
+public License()
+```
+
+### Örnekler
+
+Bu örnekte, bileşeni içeren klasörde, çağıran derlemeyi içeren klasörde, giriş derlemesinin klasöründe ve ardından çağıran derlemenin gömülü kaynaklarında MyLicense.lic adlı bir lisans dosyası bulmaya çalışılacaktır.
+
+```csharp
+[C#]
+
+License license = new License();
+license.SetLicense("MyLicense.lic");
+
+
+[Visual Basic]
+
+Dim license As license = New license
+License.SetLicense("MyLicense.lic")
+```
+
+### Ayrıca Bakınız
+
+* class [License](../../license)
+* namespace [Aspose.OMR](../../license)
+* assembly [Aspose.OMR](../../../)
+
+<!-- DÜZENLEMEYİN: xmldocmd tarafından Aspose.OMR.dll için oluşturuldu -->

--- a/turkish/cpp/aspose.omr.cpp/license/setlicense/_index.md
+++ b/turkish/cpp/aspose.omr.cpp/license/setlicense/_index.md
@@ -1,0 +1,101 @@
+---
+title: "SetLicense"
+second_title: "Aspose.OMR for .NET API Referansı"
+description: "Bileşeni lisanslar."
+type: docs
+weight: 30
+url: /tr/net/aspose.omr/license/setlicense/
+---
+## SetLicense(string) {#setlicense_1}
+
+Bileşeni lisanslar.
+
+```csharp
+public void SetLicense(string licenseName)
+```
+
+### Açıklamalar
+
+Lisansı aşağıdaki konumlarda bulmaya çalışır:
+
+1. Açık yol.
+
+2. Aspose bileşen derlemesini içeren klasör.
+
+3. İstemcinin çağıran derlemesini içeren klasör.
+
+4. Giriş (başlangıç) derlemesini içeren klasör.
+
+5. İstemcinin çağıran derlemesindeki gömülü kaynak.
+
+**Note:**On the .NET Compact Framework, tries to find the license only in these locations:
+
+1. Açık yol.
+
+2. İstemcinin çağıran derlemesindeki gömülü kaynak.
+
+### Örnekler
+
+Bu örnekte, bileşeni içeren klasörde, çağıran derlemeyi içeren klasörde, giriş derlemesinin klasöründe ve ardından çağıran derlemenin gömülü kaynaklarında MyLicense.lic adlı bir lisans dosyası bulmaya çalışılacaktır.
+
+```csharp
+[C#]
+
+License license = new License();
+license.SetLicense("MyLicense.lic");
+
+
+[Visual Basic]
+
+Dim license As License = New License
+license.SetLicense("MyLicense.lic")
+```
+
+Tam veya kısa dosya adı ya da gömülü kaynağın adı olabilir. Değerlendirme moduna geçmek için boş bir dize kullanın.
+
+### Ayrıca Bakınız
+
+* class [License](../../license)
+* namespace [Aspose.OMR](../../license)
+* assembly [Aspose.OMR](../../../)
+
+---
+
+## SetLicense(Stream) {#setlicense}
+
+Bileşeni lisanslar.
+
+```csharp
+public void SetLicense(Stream stream)
+```
+
+| Parametre | Tür | Açıklama |
+| --- | --- | --- |
+| akış | Akış | Lisansı içeren bir akış. |
+
+### Açıklamalar
+
+Bir akıştan lisans yüklemek için bu yöntemi kullanın.
+
+### Örnekler
+
+```csharp
+[C#]
+
+License license = new License();
+license.SetLicense(myStream);
+
+
+[Visual Basic]
+
+Dim license as License = new License
+license.SetLicense(myStream)
+```
+
+### Ayrıca Bakınız
+
+* class [License](../../license)
+* namespace [Aspose.OMR](../../license)
+* assembly [Aspose.OMR](../../../)
+
+<!-- DÜZENLEMEYİN: xmldocmd tarafından Aspose.OMR.dll için oluşturuldu -->

--- a/turkish/cpp/aspose.omr.cpp/metered/_index.md
+++ b/turkish/cpp/aspose.omr.cpp/metered/_index.md
@@ -1,0 +1,60 @@
+---
+title: "Ölçülen"
+second_title: "Aspose.OMR for .NET API Referansı"
+description: "Ölçülen anahtarı ayarlamak için yöntemler sağlar."
+type: docs
+weight: 10
+url: /tr/net/aspose.omr/metered/
+---
+## Metered class
+
+Ölçülen anahtarı ayarlamak için yöntemler sağlar.
+
+```csharp
+public class Metered
+```
+
+## Yapıcılar
+
+| Ad | Açıklama |
+| --- | --- |
+| [Metered](metered)() | Bu sınıfın yeni bir örneğini başlatır. |
+
+## Yöntemler
+
+| Ad | Açıklama |
+| --- | --- |
+| [SetMeteredKey](../../aspose.omr/metered/setmeteredkey)(string, string) | Ölçülen genel ve özel anahtarı ayarlar |
+| static [GetConsumptionCredit](../../aspose.omr/metered/getconsumptioncredit)() | Tüketim kredisini alır |
+| static [GetConsumptionQuantity](../../aspose.omr/metered/getconsumptionquantity)() | Tüketim dosya boyutunu alır |
+
+### Örnekler
+
+Bu örnekte, ölçülen genel ve özel anahtarı ayarlamaya çalışılacak
+
+```csharp
+[C#]
+
+Metered matered = new Metered();
+matered.SetMeteredKey("PublicKey", "PrivateKey");
+
+
+[Visual Basic]
+
+Dim matered As Metered = New Metered
+matered.SetMeteredKey("PublicKey", "PrivateKey")
+```
+
+bileşen jar dosyası:
+
+```csharp
+Metered matered = new Metered();
+matered.setMeteredKey("PublicKey", "PrivateKey");
+```
+
+### Ayrıca Bakınız
+
+* namespace [Aspose.OMR](../../aspose.omr)
+* assembly [Aspose.OMR](../../)
+
+<!-- DÜZENLEMEYİN: xmldocmd tarafından Aspose.OMR.dll için oluşturuldu -->

--- a/turkish/cpp/aspose.omr.cpp/metered/getconsumptioncredit/_index.md
+++ b/turkish/cpp/aspose.omr.cpp/metered/getconsumptioncredit/_index.md
@@ -1,0 +1,27 @@
+---
+title: "GetConsumptionCredit"
+second_title: "Aspose.OMR for .NET API Referansı"
+description: "Tüketim kredisini alır"
+type: docs
+weight: 30
+url: /tr/net/aspose.omr/metered/getconsumptioncredit/
+---
+## Metered.GetConsumptionCredit method
+
+Tüketim kredisini alır
+
+```csharp
+public static decimal GetConsumptionCredit()
+```
+
+### Dönüş Değeri
+
+tüketim miktarı
+
+### Ayrıca Bakınız
+
+* class [Metered](../../metered)
+* namespace [Aspose.OMR](../../metered)
+* assembly [Aspose.OMR](../../../)
+
+<!-- DÜZENLEMEYİN: xmldocmd tarafından Aspose.OMR.dll için oluşturuldu -->

--- a/turkish/cpp/aspose.omr.cpp/metered/getconsumptionquantity/_index.md
+++ b/turkish/cpp/aspose.omr.cpp/metered/getconsumptionquantity/_index.md
@@ -1,0 +1,27 @@
+---
+title: "GetConsumptionQuantity"
+second_title: "Aspose.OMR for .NET API Referansı"
+description: "Tüketim dosya boyutunu alır"
+type: docs
+weight: 40
+url: /tr/net/aspose.omr/metered/getconsumptionquantity/
+---
+## Metered.GetConsumptionQuantity method
+
+Tüketim dosya boyutunu alır
+
+```csharp
+public static decimal GetConsumptionQuantity()
+```
+
+### Dönüş Değeri
+
+tüketim miktarı
+
+### Ayrıca Bakınız
+
+* class [Metered](../../metered)
+* namespace [Aspose.OMR](../../metered)
+* assembly [Aspose.OMR](../../../)
+
+<!-- DÜZENLEMEYİN: xmldocmd tarafından Aspose.OMR.dll için oluşturuldu -->

--- a/turkish/cpp/aspose.omr.cpp/metered/metered/_index.md
+++ b/turkish/cpp/aspose.omr.cpp/metered/metered/_index.md
@@ -1,0 +1,23 @@
+---
+title: "Ölçülen"
+second_title: "Aspose.OMR for .NET API Referansı"
+description: "Bu sınıfın yeni bir örneğini başlatır."
+type: docs
+weight: 10
+url: /tr/net/aspose.omr/metered/metered/
+---
+## Metered constructor
+
+Bu sınıfın yeni bir örneğini başlatır.
+
+```csharp
+public Metered()
+```
+
+### Ayrıca Bakınız
+
+* class [Metered](../../metered)
+* namespace [Aspose.OMR](../../metered)
+* assembly [Aspose.OMR](../../../)
+
+<!-- DÜZENLEMEYİN: xmldocmd tarafından Aspose.OMR.dll için oluşturuldu -->

--- a/turkish/cpp/aspose.omr.cpp/metered/setmeteredkey/_index.md
+++ b/turkish/cpp/aspose.omr.cpp/metered/setmeteredkey/_index.md
@@ -1,0 +1,28 @@
+---
+title: "SetMeteredKey"
+second_title: "Aspose.OMR for .NET API Referansı"
+description: "Ölçülen genel ve özel anahtarı ayarlar"
+type: docs
+weight: 20
+url: /tr/net/aspose.omr/metered/setmeteredkey/
+---
+## Metered.SetMeteredKey method
+
+Ölçülen genel ve özel anahtarı ayarlar
+
+```csharp
+public void SetMeteredKey(string publicKey, string privateKey)
+```
+
+| Parametre | Tür | Açıklama |
+| --- | --- | --- |
+| publicKey | String | açık anahtar |
+| privateKey | String | özel anahtar |
+
+### Ayrıca Bakınız
+
+* class [Metered](../../metered)
+* namespace [Aspose.OMR](../../metered)
+* assembly [Aspose.OMR](../../../)
+
+<!-- DÜZENLEMEYİN: xmldocmd tarafından Aspose.OMR.dll için oluşturuldu -->


### PR DESCRIPTION
Automated translation of the CPP API Reference to **Turkish** (`tr`) generated by RDA.

- Pages translated: 11/11
- Errors: 0
- Source: `english/cpp`
- Output: `turkish/cpp`

🤖 Generated by RDA