### PR TITLE
[auto] Translate JAVA API Reference to Japanese

### DIFF
--- a/japanese/java/_index.md
+++ b/japanese/java/_index.md
@@ -1,0 +1,13 @@
+---
+title: "Aspose.OMR for Java"
+type: docs
+weight: 11
+url: /ja/java/
+description: "Aspose.OMR for Java API リファレンスには、サンプル、コードスニペット、および API ドキュメントが含まれています。パッケージ、クラス、インターフェイス、その他の API 詳細が提供されます。"
+is_root: true
+---
+
+## Packages
+| パッケージ | 説明 |
+| --- | --- |
+| [com.aspose.omr](./com.aspose.omr/) | この **com.aspose.omr** パッケージは、OMR フォームの作成と認識のためのクラスを提供します。 |

--- a/japanese/java/com.aspose.omr/_index.md
+++ b/japanese/java/com.aspose.omr/_index.md
@@ -1,0 +1,57 @@
+---
+title: "com.aspose.omr"
+second_title: "Aspose.OMR for Java API リファレンス"
+description: "この com.aspose.omr パッケージは、OMR フォームの作成と認識のためのクラスを提供します。"
+type: docs
+weight: 10
+url: /ja/java/com.aspose.omr/
+---
+
+
+この **com.aspose.omr** パッケージは、OMR フォームの作成と認識のためのクラスを提供します。
+
+
+## クラス
+
+| クラス | 説明 |
+| --- | --- |
+| [BarcodeElement](../com.aspose.omr/barcodeelement/) | バーコード要素を表します |
+| [ChoiceBoxElement](../com.aspose.omr/choiceboxelement/) | ChoiceBox 質問を表します |
+| [ClipAreaElement](../com.aspose.omr/clipareaelement/) | クリップ領域要素を表します |
+| [FinalizationData](../com.aspose.omr/finalizationdata/) | 最終化データを表します |
+| [GenerationResult](../com.aspose.omr/generationresult/) | テンプレート生成の結果です。 |
+| [GlobalPageSettings](../com.aspose.omr/globalpagesettings/) | すべてのページ要素に適用されるグローバル設定です。 |
+| [GridElement](../com.aspose.omr/gridelement/) |  |
+| [ImageCollection](../com.aspose.omr/imagecollection/) | テンプレート生成に使用できる画像のコレクションです。 |
+| [License](../com.aspose.omr/license/) | コンポーネントをライセンスするためのメソッドを提供します。 |
+| [Metered](../com.aspose.omr/metered/) | メーターキーを設定するためのメソッドを提供します。 |
+| [OmrBubble](../com.aspose.omr/omrbubble/) | 単一の OMR バブルを表します |
+| [OmrElement](../com.aspose.omr/omrelement/) | 基本 OMR 質問を表す抽象クラスです。すべての質問に共通のプロパティを含みます。 |
+| [OmrEngine](../com.aspose.omr/omrengine/) | OMR エンジンです。 |
+| [OmrImage](../com.aspose.omr/omrimage/) |  |
+| [OmrPage](../com.aspose.omr/omrpage/) | 単一の OMR ページを表します |
+| [OmrTemplate](../com.aspose.omr/omrtemplate/) | OMR テンプレートを表します |
+| [Orientations](../com.aspose.omr/orientations/) | 可能な質問の向き |
+| [RecognitionResult](../com.aspose.omr/recognitionresult/) | 画像認識の結果。 |
+| [ReferencePointElement](../com.aspose.omr/referencepointelement/) |  |
+| [ReferencePointsSettings](../com.aspose.omr/referencepointssettings/) | すべてのページ要素に適用される参照点のグローバル設定。 |
+| [TemplateProcessor](../com.aspose.omr/templateprocessor/) | テンプレートと画像を処理するクラス。 |
+
+## インターフェイス
+
+| インターフェイス | 説明 |
+| --- | --- |
+| [IOmrElement](../com.aspose.omr/iomrelement/) | OMR要素のインターフェイス |
+
+## 列挙体
+
+| 列挙体 | 説明 |
+| --- | --- |
+| [Alignment](../com.aspose.omr/alignment/) |  |
+| [BarcodeType](../com.aspose.omr/barcodetype/) | バーコード生成\\認識で許可されるバーコードのタイプ |
+| [BubbleSize](../com.aspose.omr/bubblesize/) |  |
+| [DrawingColor](../com.aspose.omr/drawingcolor/) | テンプレート生成で使用される色 |
+| [FontStyle](../com.aspose.omr/fontstyle/) |  |
+| [PaperSize](../com.aspose.omr/papersize/) | サポートされている用紙サイズ |
+| [QrVersion](../com.aspose.omr/qrversion/) |  |
+| [RotationPointPosition](../com.aspose.omr/rotationpointposition/) |  |

--- a/japanese/java/com.aspose.omr/alignment/_index.md
+++ b/japanese/java/com.aspose.omr/alignment/_index.md
@@ -1,0 +1,248 @@
+---
+title: "配置"
+second_title: "Aspose.OMR for Java API リファレンス"
+description: 
+type: docs
+weight: 32
+url: /ja/java/com.aspose.omr/alignment/
+---
+
+**Inheritance:**
+java.lang.Object, java.lang.Enum
+```
+public enum Alignment extends Enum<Alignment>
+```
+## フィールド
+
+| フィールド | 説明 |
+| --- | --- |
+| [Center](#Center) |  |
+| [Left](#Left) |  |
+| [Right](#Right) |  |
+| [undefined](#undefined) |  |
+## メソッド
+
+| メソッド | 説明 |
+| --- | --- |
+| [<T>valueOf(Class<T> arg0, String arg1)](#-T-valueOf-java.lang.Class-T--java.lang.String) |  |
+| [compareTo(E arg0)](#compareTo-E) |  |
+| [equals(Object arg0)](#equals-java.lang.Object) |  |
+| [getClass()](#getClass) |  |
+| [getDeclaringClass()](#getDeclaringClass) |  |
+| [hashCode()](#hashCode) |  |
+| [name()](#name) |  |
+| [notify()](#notify) |  |
+| [notifyAll()](#notifyAll) |  |
+| [ordinal()](#ordinal) |  |
+| [toString()](#toString) |  |
+| [valueOf(String name)](#valueOf-java.lang.String) |  |
+| [values()](#values) |  |
+| [wait()](#wait) |  |
+| [wait(long arg0)](#wait-long) |  |
+| [wait(long arg0, int arg1)](#wait-long-int) |  |
+### Center {#Center}
+```
+public static final Alignment Center
+```
+
+
+### Left {#Left}
+```
+public static final Alignment Left
+```
+
+
+### Right {#Right}
+```
+public static final Alignment Right
+```
+
+
+### undefined {#undefined}
+```
+public static final Alignment undefined
+```
+
+
+### <T>valueOf(Class<T> arg0, String arg1) {#-T-valueOf-java.lang.Class-T--java.lang.String}
+```
+public static T <T>valueOf(Class<T> arg0, String arg1)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | java.lang.Class<T> |  |
+| arg1 | java.lang.String |  |
+
+**Returns:**
+T
+### compareTo(E arg0) {#compareTo-E}
+```
+public final int compareTo(E arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | E |  |
+
+**Returns:**
+int
+### equals(Object arg0) {#equals-java.lang.Object}
+```
+public final boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getDeclaringClass() {#getDeclaringClass}
+```
+public final Class<E> getDeclaringClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<E>
+### hashCode() {#hashCode}
+```
+public final int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### name() {#name}
+```
+public final String name()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### notify() {#notify}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### ordinal() {#ordinal}
+```
+public final int ordinal()
+```
+
+
+
+
+**Returns:**
+int
+### toString() {#toString}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### valueOf(String name) {#valueOf-java.lang.String}
+```
+public static Alignment valueOf(String name)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 名前 | java.lang.String |  |
+
+**Returns:**
+[Alignment](../../com.aspose.omr/alignment/)
+### values() {#values}
+```
+public static Alignment[] values()
+```
+
+
+
+
+**Returns:**
+com.aspose.omr.Alignment[]
+### wait() {#wait}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/japanese/java/com.aspose.omr/barcodeelement/_index.md
+++ b/japanese/java/com.aspose.omr/barcodeelement/_index.md
@@ -1,0 +1,297 @@
+---
+title: "BarcodeElement"
+second_title: "Aspose.OMR for Java API リファレンス"
+description: "バーコード要素を表します"
+type: docs
+weight: 10
+url: /ja/java/com.aspose.omr/barcodeelement/
+---
+
+**Inheritance:**
+java.lang.Object, [com.aspose.omr.OmrElement](../../com.aspose.omr/omrelement/)
+```
+public class BarcodeElement extends OmrElement
+```
+
+バーコード要素を表します
+## コンストラクタ
+
+| コンストラクタ | 説明 |
+| --- | --- |
+| [BarcodeElement()](#BarcodeElement) |  |
+## フィールド
+
+| フィールド | 説明 |
+| --- | --- |
+| [BarcodeType](#BarcodeType) |  |
+| [ElementType](#ElementType) |  |
+| [QrVersion](#QrVersion) |  |
+## メソッド
+
+| メソッド | 説明 |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object) |  |
+| [getClass()](#getClass) |  |
+| [getHeight()](#getHeight) | 質問の高さを取得または設定します |
+| [getLeft()](#getLeft) | 質問の左位置を取得または設定します |
+| [getName()](#getName) | 質問名を取得します |
+| [getRect()](#getRect) |  |
+| [getTop()](#getTop) | 質問の上位置を取得または設定します |
+| [getWidth()](#getWidth) | 質問の幅を取得または設定します |
+| [hashCode()](#hashCode) |  |
+| [notify()](#notify) |  |
+| [notifyAll()](#notifyAll) |  |
+| [setHeight(double value)](#setHeight-double) | 質問の高さを取得または設定します |
+| [setLeft(double value)](#setLeft-double) | 質問の左位置を取得または設定します |
+| [setName(String value)](#setName-java.lang.String) | 質問名を設定します |
+| [setTop(double value)](#setTop-double) | 質問の上位置を取得または設定します |
+| [setWidth(double value)](#setWidth-double) | 質問の幅を取得または設定します |
+| [toString()](#toString) |  |
+| [wait()](#wait) |  |
+| [wait(long arg0)](#wait-long) |  |
+| [wait(long arg0, int arg1)](#wait-long-int) |  |
+### BarcodeElement() {#BarcodeElement}
+```
+public BarcodeElement()
+```
+
+
+### BarcodeType {#BarcodeType}
+```
+public BarcodeType BarcodeType
+```
+
+
+### ElementType {#ElementType}
+```
+public String ElementType
+```
+
+
+### QrVersion {#QrVersion}
+```
+public QrVersion QrVersion
+```
+
+
+### equals(Object arg0) {#equals-java.lang.Object}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getHeight() {#getHeight}
+```
+public final double getHeight()
+```
+
+
+質問の高さを取得または設定します
+
+**Returns:**
+double - 高さ
+### getLeft() {#getLeft}
+```
+public final double getLeft()
+```
+
+
+質問の左位置を取得または設定します
+
+**Returns:**
+double - 左
+### getName() {#getName}
+```
+public final String getName()
+```
+
+
+質問名を取得します
+
+**Returns:**
+java.lang.String - 質問名
+### getRect() {#getRect}
+```
+public System.Drawing.RectangleF getRect()
+```
+
+
+
+
+**Returns:**
+com.aspose.ms.System.Drawing.RectangleF
+### getTop() {#getTop}
+```
+public final double getTop()
+```
+
+
+質問の上位置を取得または設定します
+
+**Returns:**
+double - 上
+### getWidth() {#getWidth}
+```
+public final double getWidth()
+```
+
+
+質問の幅を取得または設定します
+
+**Returns:**
+double - 幅
+### hashCode() {#hashCode}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setHeight(double value) {#setHeight-double}
+```
+public final void setHeight(double value)
+```
+
+
+質問の高さを取得または設定します
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | double | 高さ |
+
+### setLeft(double value) {#setLeft-double}
+```
+public final void setLeft(double value)
+```
+
+
+質問の左位置を取得または設定します
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | double | 左 |
+
+### setName(String value) {#setName-java.lang.String}
+```
+public final void setName(String value)
+```
+
+
+質問名を設定します
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | java.lang.String | 質問名 |
+
+### setTop(double value) {#setTop-double}
+```
+public final void setTop(double value)
+```
+
+
+質問の上位置を取得または設定します
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | double | 上 |
+
+### setWidth(double value) {#setWidth-double}
+```
+public final void setWidth(double value)
+```
+
+
+質問の幅を取得または設定します
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | double | 幅 |
+
+### toString() {#toString}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/japanese/java/com.aspose.omr/barcodetype/_index.md
+++ b/japanese/java/com.aspose.omr/barcodetype/_index.md
@@ -1,0 +1,987 @@
+---
+title: "バーコードタイプ"
+second_title: "Aspose.OMR for Java API リファレンス"
+description: "バーコード生成認識で許可されるバーコードのタイプ"
+type: docs
+weight: 33
+url: /ja/java/com.aspose.omr/barcodetype/
+---
+
+**Inheritance:**
+java.lang.Object, java.lang.Enum
+```
+public enum BarcodeType extends Enum<BarcodeType>
+```
+
+バーコード生成\\認識で許可されるバーコードのタイプ
+## フィールド
+
+| フィールド | 説明 |
+| --- | --- |
+| [AustraliaPost](#AustraliaPost) | AustraliaPost タイプを表す |
+| [AustralianPosteParcel](#AustralianPosteParcel) | AustralianPosteParcel タイプを表す |
+| [Aztec](#Aztec) | Aztec タイプを表す |
+| [Codabar](#Codabar) | Codabar タイプを表す |
+| [CodablockF](#CodablockF) | CodablockF タイプを表す |
+| [Code11](#Code11) | Code11 タイプを表す |
+| [Code128](#Code128) | Code128 タイプを表す |
+| [Code16K](#Code16K) | Code16K タイプを表す |
+| [Code32](#Code32) | Code32 タイプを表す |
+| [Code39](#Code39) | Code39 タイプを表す |
+| [Code39FullASCII](#Code39FullASCII) | Code39FullASCII タイプを表す |
+| [Code93](#Code93) | Code93 タイプを表す |
+| [DataLogic2of5](#DataLogic2of5) | DataLogic2of5 タイプを表す |
+| [DataMatrix](#DataMatrix) | DataMatrix タイプを表す |
+| [DatabarExpanded](#DatabarExpanded) | DatabarExpanded タイプを表す |
+| [DatabarExpandedStacked](#DatabarExpandedStacked) | DatabarExpandedStacked タイプを表す |
+| [DatabarLimited](#DatabarLimited) | DatabarLimited タイプを表す |
+| [DatabarOmniDirectional](#DatabarOmniDirectional) | DatabarOmniDirectional タイプを表す |
+| [DatabarStacked](#DatabarStacked) | DatabarStacked タイプを表す |
+| [DatabarStackedOmniDirectional](#DatabarStackedOmniDirectional) | DatabarStackedOmniDirectional タイプを表す |
+| [DatabarTruncated](#DatabarTruncated) | DatabarTruncated タイプを表す |
+| [DeutschePostIdentcode](#DeutschePostIdentcode) | DeutschePostIdentcode タイプを表す |
+| [DeutschePostLeitcode](#DeutschePostLeitcode) | DeutschePostLeitcode タイプを表す |
+| [DotCode](#DotCode) | DotCode タイプを表す |
+| [DutchKIX](#DutchKIX) | DutchKIX タイプを表す |
+| [EAN13](#EAN13) | EAN13 タイプを表す |
+| [EAN14](#EAN14) | EAN14 タイプを表す |
+| [EAN8](#EAN8) | EAN8 タイプを表す |
+| [GS1Aztec](#GS1Aztec) | GS1Aztec タイプを表す |
+| [GS1CodablockF](#GS1CodablockF) | GS1CodablockF タイプを表す |
+| [GS1Code128](#GS1Code128) | GS1Code128 タイプを表す |
+| [GS1CompositeBar](#GS1CompositeBar) | GS1CompositeBar タイプを表す |
+| [GS1DataMatrix](#GS1DataMatrix) | GS1DataMatrix タイプを表す |
+| [GS1DotCode](#GS1DotCode) | GS1DotCode タイプを表す |
+| [GS1HanXin](#GS1HanXin) | GS1HanXin タイプを表す |
+| [GS1MicroPdf417](#GS1MicroPdf417) | GS1MicroPdf417 タイプを表す |
+| [GS1QR](#GS1QR) | GS1QR タイプを表す |
+| [HIBCAztecLIC](#HIBCAztecLIC) | HIBCAztecLIC タイプを表す |
+| [HIBCAztecPAS](#HIBCAztecPAS) | HIBCAztecPAS タイプを表す |
+| [HIBCCode128LIC](#HIBCCode128LIC) | HIBCCode128LIC タイプを表す |
+| [HIBCCode128PAS](#HIBCCode128PAS) | HIBCCode128PAS タイプを表す |
+| [HIBCCode39LIC](#HIBCCode39LIC) | HIBCCode39LIC タイプを表す |
+| [HIBCCode39PAS](#HIBCCode39PAS) | HIBCCode39PAS タイプを表す |
+| [HIBCDataMatrixLIC](#HIBCDataMatrixLIC) | HIBCDataMatrixLIC タイプを表す |
+| [HIBCDataMatrixPAS](#HIBCDataMatrixPAS) | HIBCDataMatrixPAS タイプを表す |
+| [HIBCQRLIC](#HIBCQRLIC) | HIBCQRLIC タイプを表す |
+| [HIBCQRPAS](#HIBCQRPAS) | HIBCQRPAS タイプを表す |
+| [HanXin](#HanXin) | HanXin タイプを表す |
+| [IATA2of5](#IATA2of5) | IATA2of5 タイプを表す |
+| [ISBN](#ISBN) | ISBN タイプを表す |
+| [ISMN](#ISMN) | ISMN タイプを表す |
+| [ISSN](#ISSN) | ISSN タイプを表す |
+| [ITF14](#ITF14) | ITF14 タイプを表す |
+| [ITF6](#ITF6) | ITF6 タイプを表す |
+| [Interleaved2of5](#Interleaved2of5) | Interleaved2of5 タイプを表す |
+| [ItalianPost25](#ItalianPost25) | ItalianPost25 タイプを表す |
+| [MSI](#MSI) | MSI タイプを表す |
+| [MacroPdf417](#MacroPdf417) | MacroPdf417 タイプを表す |
+| [Mailmark](#Mailmark) | Mailmark タイプを表す |
+| [Matrix2of5](#Matrix2of5) | Matrix2of5 タイプを表す |
+| [MaxiCode](#MaxiCode) | MaxiCode タイプを表す |
+| [MicroPdf417](#MicroPdf417) | MicroPdf417 タイプを表す |
+| [MicroQR](#MicroQR) | MicroQR タイプを表す |
+| [OPC](#OPC) | OPC タイプを表す |
+| [OneCode](#OneCode) | OneCode タイプを表す |
+| [PZN](#PZN) | PZN タイプを表す |
+| [PatchCode](#PatchCode) | PatchCode タイプを表す |
+| [Pdf417](#Pdf417) | Pdf417 タイプを表す |
+| [Pharmacode](#Pharmacode) | Pharmacode タイプを表す |
+| [Planet](#Planet) | Planet タイプを表す |
+| [Postnet](#Postnet) | Postnet タイプを表す |
+| [QR](#QR) | QR タイプを表す |
+| [RM4SCC](#RM4SCC) | RM4SCC タイプを表す |
+| [RectMicroQR](#RectMicroQR) | RectMicroQR タイプを表す |
+| [SCC14](#SCC14) | SCC14 タイプを表す |
+| [SSCC18](#SSCC18) | SSCC18 タイプを表す |
+| [SingaporePost](#SingaporePost) | SingaporePost タイプを表す |
+| [Standard2of5](#Standard2of5) | Standard2of5 タイプを表す |
+| [SwissPostParcel](#SwissPostParcel) | SwissPostParcel タイプを表す |
+| [UPCA](#UPCA) | UPCA タイプを表す |
+| [UPCE](#UPCE) | UPCE タイプを表す |
+| [UpcaGs1Code128Coupon](#UpcaGs1Code128Coupon) | UpcaGs1Code128Coupon タイプを表す |
+| [UpcaGs1DatabarCoupon](#UpcaGs1DatabarCoupon) | UpcaGs1DatabarCoupon タイプを表す |
+| [VIN](#VIN) | VIN タイプを表す |
+| [undefined](#undefined) | 値が設定されていません。 |
+## メソッド
+
+| メソッド | 説明 |
+| --- | --- |
+| [<T>valueOf(Class<T> arg0, String arg1)](#-T-valueOf-java.lang.Class-T--java.lang.String) |  |
+| [compareTo(E arg0)](#compareTo-E) |  |
+| [equals(Object arg0)](#equals-java.lang.Object) |  |
+| [getClass()](#getClass) |  |
+| [getDeclaringClass()](#getDeclaringClass) |  |
+| [hashCode()](#hashCode) |  |
+| [name()](#name) |  |
+| [notify()](#notify) |  |
+| [notifyAll()](#notifyAll) |  |
+| [ordinal()](#ordinal) |  |
+| [toString()](#toString) |  |
+| [valueOf(String name)](#valueOf-java.lang.String) |  |
+| [values()](#values) |  |
+| [wait()](#wait) |  |
+| [wait(long arg0)](#wait-long) |  |
+| [wait(long arg0, int arg1)](#wait-long-int) |  |
+### AustraliaPost {#AustraliaPost}
+```
+public static final BarcodeType AustraliaPost
+```
+
+
+AustraliaPost タイプを表す
+
+### AustralianPosteParcel {#AustralianPosteParcel}
+```
+public static final BarcodeType AustralianPosteParcel
+```
+
+
+AustralianPosteParcel タイプを表す
+
+### Aztec {#Aztec}
+```
+public static final BarcodeType Aztec
+```
+
+
+Aztec タイプを表す
+
+### Codabar {#Codabar}
+```
+public static final BarcodeType Codabar
+```
+
+
+Codabar タイプを表す
+
+### CodablockF {#CodablockF}
+```
+public static final BarcodeType CodablockF
+```
+
+
+CodablockF タイプを表す
+
+### Code11 {#Code11}
+```
+public static final BarcodeType Code11
+```
+
+
+Code11 タイプを表す
+
+### Code128 {#Code128}
+```
+public static final BarcodeType Code128
+```
+
+
+Code128 タイプを表す
+
+### Code16K {#Code16K}
+```
+public static final BarcodeType Code16K
+```
+
+
+Code16K タイプを表す
+
+### Code32 {#Code32}
+```
+public static final BarcodeType Code32
+```
+
+
+Code32 タイプを表す
+
+### Code39 {#Code39}
+```
+public static final BarcodeType Code39
+```
+
+
+Code39 タイプを表す
+
+### Code39FullASCII {#Code39FullASCII}
+```
+public static final BarcodeType Code39FullASCII
+```
+
+
+Code39FullASCII タイプを表す
+
+### Code93 {#Code93}
+```
+public static final BarcodeType Code93
+```
+
+
+Code93 タイプを表す
+
+### DataLogic2of5 {#DataLogic2of5}
+```
+public static final BarcodeType DataLogic2of5
+```
+
+
+DataLogic2of5 タイプを表す
+
+### DataMatrix {#DataMatrix}
+```
+public static final BarcodeType DataMatrix
+```
+
+
+DataMatrix タイプを表す
+
+### DatabarExpanded {#DatabarExpanded}
+```
+public static final BarcodeType DatabarExpanded
+```
+
+
+DatabarExpanded タイプを表す
+
+### DatabarExpandedStacked {#DatabarExpandedStacked}
+```
+public static final BarcodeType DatabarExpandedStacked
+```
+
+
+DatabarExpandedStacked タイプを表す
+
+### DatabarLimited {#DatabarLimited}
+```
+public static final BarcodeType DatabarLimited
+```
+
+
+DatabarLimited タイプを表す
+
+### DatabarOmniDirectional {#DatabarOmniDirectional}
+```
+public static final BarcodeType DatabarOmniDirectional
+```
+
+
+DatabarOmniDirectional タイプを表す
+
+### DatabarStacked {#DatabarStacked}
+```
+public static final BarcodeType DatabarStacked
+```
+
+
+DatabarStacked タイプを表す
+
+### DatabarStackedOmniDirectional {#DatabarStackedOmniDirectional}
+```
+public static final BarcodeType DatabarStackedOmniDirectional
+```
+
+
+DatabarStackedOmniDirectional タイプを表す
+
+### DatabarTruncated {#DatabarTruncated}
+```
+public static final BarcodeType DatabarTruncated
+```
+
+
+DatabarTruncated タイプを表す
+
+### DeutschePostIdentcode {#DeutschePostIdentcode}
+```
+public static final BarcodeType DeutschePostIdentcode
+```
+
+
+DeutschePostIdentcode タイプを表す
+
+### DeutschePostLeitcode {#DeutschePostLeitcode}
+```
+public static final BarcodeType DeutschePostLeitcode
+```
+
+
+DeutschePostLeitcode タイプを表す
+
+### DotCode {#DotCode}
+```
+public static final BarcodeType DotCode
+```
+
+
+DotCode タイプを表す
+
+### DutchKIX {#DutchKIX}
+```
+public static final BarcodeType DutchKIX
+```
+
+
+DutchKIX タイプを表す
+
+### EAN13 {#EAN13}
+```
+public static final BarcodeType EAN13
+```
+
+
+EAN13 タイプを表す
+
+### EAN14 {#EAN14}
+```
+public static final BarcodeType EAN14
+```
+
+
+EAN14 タイプを表す
+
+### EAN8 {#EAN8}
+```
+public static final BarcodeType EAN8
+```
+
+
+EAN8 タイプを表す
+
+### GS1Aztec {#GS1Aztec}
+```
+public static final BarcodeType GS1Aztec
+```
+
+
+GS1Aztec タイプを表す
+
+### GS1CodablockF {#GS1CodablockF}
+```
+public static final BarcodeType GS1CodablockF
+```
+
+
+GS1CodablockF タイプを表す
+
+### GS1Code128 {#GS1Code128}
+```
+public static final BarcodeType GS1Code128
+```
+
+
+GS1Code128 タイプを表す
+
+### GS1CompositeBar {#GS1CompositeBar}
+```
+public static final BarcodeType GS1CompositeBar
+```
+
+
+GS1CompositeBar タイプを表す
+
+### GS1DataMatrix {#GS1DataMatrix}
+```
+public static final BarcodeType GS1DataMatrix
+```
+
+
+GS1DataMatrix タイプを表す
+
+### GS1DotCode {#GS1DotCode}
+```
+public static final BarcodeType GS1DotCode
+```
+
+
+GS1DotCode タイプを表す
+
+### GS1HanXin {#GS1HanXin}
+```
+public static final BarcodeType GS1HanXin
+```
+
+
+GS1HanXin タイプを表す
+
+### GS1MicroPdf417 {#GS1MicroPdf417}
+```
+public static final BarcodeType GS1MicroPdf417
+```
+
+
+GS1MicroPdf417 タイプを表す
+
+### GS1QR {#GS1QR}
+```
+public static final BarcodeType GS1QR
+```
+
+
+GS1QR タイプを表す
+
+### HIBCAztecLIC {#HIBCAztecLIC}
+```
+public static final BarcodeType HIBCAztecLIC
+```
+
+
+HIBCAztecLIC タイプを表す
+
+### HIBCAztecPAS {#HIBCAztecPAS}
+```
+public static final BarcodeType HIBCAztecPAS
+```
+
+
+HIBCAztecPAS タイプを表す
+
+### HIBCCode128LIC {#HIBCCode128LIC}
+```
+public static final BarcodeType HIBCCode128LIC
+```
+
+
+HIBCCode128LIC タイプを表す
+
+### HIBCCode128PAS {#HIBCCode128PAS}
+```
+public static final BarcodeType HIBCCode128PAS
+```
+
+
+HIBCCode128PAS タイプを表す
+
+### HIBCCode39LIC {#HIBCCode39LIC}
+```
+public static final BarcodeType HIBCCode39LIC
+```
+
+
+HIBCCode39LIC タイプを表す
+
+### HIBCCode39PAS {#HIBCCode39PAS}
+```
+public static final BarcodeType HIBCCode39PAS
+```
+
+
+HIBCCode39PAS タイプを表す
+
+### HIBCDataMatrixLIC {#HIBCDataMatrixLIC}
+```
+public static final BarcodeType HIBCDataMatrixLIC
+```
+
+
+HIBCDataMatrixLIC タイプを表す
+
+### HIBCDataMatrixPAS {#HIBCDataMatrixPAS}
+```
+public static final BarcodeType HIBCDataMatrixPAS
+```
+
+
+HIBCDataMatrixPAS タイプを表す
+
+### HIBCQRLIC {#HIBCQRLIC}
+```
+public static final BarcodeType HIBCQRLIC
+```
+
+
+HIBCQRLIC タイプを表す
+
+### HIBCQRPAS {#HIBCQRPAS}
+```
+public static final BarcodeType HIBCQRPAS
+```
+
+
+HIBCQRPAS タイプを表す
+
+### HanXin {#HanXin}
+```
+public static final BarcodeType HanXin
+```
+
+
+HanXin タイプを表す
+
+### IATA2of5 {#IATA2of5}
+```
+public static final BarcodeType IATA2of5
+```
+
+
+IATA2of5 タイプを表す
+
+### ISBN {#ISBN}
+```
+public static final BarcodeType ISBN
+```
+
+
+ISBN タイプを表す
+
+### ISMN {#ISMN}
+```
+public static final BarcodeType ISMN
+```
+
+
+ISMN タイプを表す
+
+### ISSN {#ISSN}
+```
+public static final BarcodeType ISSN
+```
+
+
+ISSN タイプを表す
+
+### ITF14 {#ITF14}
+```
+public static final BarcodeType ITF14
+```
+
+
+ITF14 タイプを表す
+
+### ITF6 {#ITF6}
+```
+public static final BarcodeType ITF6
+```
+
+
+ITF6 タイプを表す
+
+### Interleaved2of5 {#Interleaved2of5}
+```
+public static final BarcodeType Interleaved2of5
+```
+
+
+Interleaved2of5 タイプを表す
+
+### ItalianPost25 {#ItalianPost25}
+```
+public static final BarcodeType ItalianPost25
+```
+
+
+ItalianPost25 タイプを表す
+
+### MSI {#MSI}
+```
+public static final BarcodeType MSI
+```
+
+
+MSI タイプを表す
+
+### MacroPdf417 {#MacroPdf417}
+```
+public static final BarcodeType MacroPdf417
+```
+
+
+MacroPdf417 タイプを表す
+
+### Mailmark {#Mailmark}
+```
+public static final BarcodeType Mailmark
+```
+
+
+Mailmark タイプを表す
+
+### Matrix2of5 {#Matrix2of5}
+```
+public static final BarcodeType Matrix2of5
+```
+
+
+Matrix2of5 タイプを表す
+
+### MaxiCode {#MaxiCode}
+```
+public static final BarcodeType MaxiCode
+```
+
+
+MaxiCode タイプを表す
+
+### MicroPdf417 {#MicroPdf417}
+```
+public static final BarcodeType MicroPdf417
+```
+
+
+MicroPdf417 タイプを表す
+
+### MicroQR {#MicroQR}
+```
+public static final BarcodeType MicroQR
+```
+
+
+MicroQR タイプを表す
+
+### OPC {#OPC}
+```
+public static final BarcodeType OPC
+```
+
+
+OPC タイプを表す
+
+### OneCode {#OneCode}
+```
+public static final BarcodeType OneCode
+```
+
+
+OneCode タイプを表す
+
+### PZN {#PZN}
+```
+public static final BarcodeType PZN
+```
+
+
+PZN タイプを表す
+
+### PatchCode {#PatchCode}
+```
+public static final BarcodeType PatchCode
+```
+
+
+PatchCode タイプを表す
+
+### Pdf417 {#Pdf417}
+```
+public static final BarcodeType Pdf417
+```
+
+
+Pdf417 タイプを表す
+
+### Pharmacode {#Pharmacode}
+```
+public static final BarcodeType Pharmacode
+```
+
+
+Pharmacode タイプを表す
+
+### Planet {#Planet}
+```
+public static final BarcodeType Planet
+```
+
+
+Planet タイプを表す
+
+### Postnet {#Postnet}
+```
+public static final BarcodeType Postnet
+```
+
+
+Postnet タイプを表す
+
+### QR {#QR}
+```
+public static final BarcodeType QR
+```
+
+
+QR タイプを表す
+
+### RM4SCC {#RM4SCC}
+```
+public static final BarcodeType RM4SCC
+```
+
+
+RM4SCC タイプを表す
+
+### RectMicroQR {#RectMicroQR}
+```
+public static final BarcodeType RectMicroQR
+```
+
+
+RectMicroQR タイプを表す
+
+### SCC14 {#SCC14}
+```
+public static final BarcodeType SCC14
+```
+
+
+SCC14 タイプを表す
+
+### SSCC18 {#SSCC18}
+```
+public static final BarcodeType SSCC18
+```
+
+
+SSCC18 タイプを表す
+
+### SingaporePost {#SingaporePost}
+```
+public static final BarcodeType SingaporePost
+```
+
+
+SingaporePost タイプを表す
+
+### Standard2of5 {#Standard2of5}
+```
+public static final BarcodeType Standard2of5
+```
+
+
+Standard2of5 タイプを表す
+
+### SwissPostParcel {#SwissPostParcel}
+```
+public static final BarcodeType SwissPostParcel
+```
+
+
+SwissPostParcel タイプを表す
+
+### UPCA {#UPCA}
+```
+public static final BarcodeType UPCA
+```
+
+
+UPCA タイプを表す
+
+### UPCE {#UPCE}
+```
+public static final BarcodeType UPCE
+```
+
+
+UPCE タイプを表す
+
+### UpcaGs1Code128Coupon {#UpcaGs1Code128Coupon}
+```
+public static final BarcodeType UpcaGs1Code128Coupon
+```
+
+
+UpcaGs1Code128Coupon タイプを表す
+
+### UpcaGs1DatabarCoupon {#UpcaGs1DatabarCoupon}
+```
+public static final BarcodeType UpcaGs1DatabarCoupon
+```
+
+
+UpcaGs1DatabarCoupon タイプを表す
+
+### VIN {#VIN}
+```
+public static final BarcodeType VIN
+```
+
+
+VIN タイプを表す
+
+### undefined {#undefined}
+```
+public static final BarcodeType undefined
+```
+
+
+値が設定されていません。デフォルト値が使用されます
+
+### <T>valueOf(Class<T> arg0, String arg1) {#-T-valueOf-java.lang.Class-T--java.lang.String}
+```
+public static T <T>valueOf(Class<T> arg0, String arg1)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | java.lang.Class<T> |  |
+| arg1 | java.lang.String |  |
+
+**Returns:**
+T
+### compareTo(E arg0) {#compareTo-E}
+```
+public final int compareTo(E arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | E |  |
+
+**Returns:**
+int
+### equals(Object arg0) {#equals-java.lang.Object}
+```
+public final boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getDeclaringClass() {#getDeclaringClass}
+```
+public final Class<E> getDeclaringClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<E>
+### hashCode() {#hashCode}
+```
+public final int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### name() {#name}
+```
+public final String name()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### notify() {#notify}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### ordinal() {#ordinal}
+```
+public final int ordinal()
+```
+
+
+
+
+**Returns:**
+int
+### toString() {#toString}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### valueOf(String name) {#valueOf-java.lang.String}
+```
+public static BarcodeType valueOf(String name)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 名前 | java.lang.String |  |
+
+**Returns:**
+[BarcodeType](../../com.aspose.omr/barcodetype/)
+### values() {#values}
+```
+public static BarcodeType[] values()
+```
+
+
+
+
+**Returns:**
+com.aspose.omr.BarcodeType[]
+### wait() {#wait}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/japanese/java/com.aspose.omr/bubblesize/_index.md
+++ b/japanese/java/com.aspose.omr/bubblesize/_index.md
@@ -1,0 +1,262 @@
+---
+title: "BubbleSize"
+second_title: "Aspose.OMR for Java API リファレンス"
+description: 
+type: docs
+weight: 34
+url: /ja/java/com.aspose.omr/bubblesize/
+---
+
+**Inheritance:**
+java.lang.Object, java.lang.Enum
+```
+public enum BubbleSize extends Enum<BubbleSize>
+```
+## フィールド
+
+| フィールド | 説明 |
+| --- | --- |
+| [Extralarge](#Extralarge) |  |
+| [Extrasmall](#Extrasmall) |  |
+| [Large](#Large) |  |
+| [Normal](#Normal) |  |
+| [Small](#Small) |  |
+| [undefined](#undefined) |  |
+## メソッド
+
+| メソッド | 説明 |
+| --- | --- |
+| [<T>valueOf(Class<T> arg0, String arg1)](#-T-valueOf-java.lang.Class-T--java.lang.String) |  |
+| [compareTo(E arg0)](#compareTo-E) |  |
+| [equals(Object arg0)](#equals-java.lang.Object) |  |
+| [getClass()](#getClass) |  |
+| [getDeclaringClass()](#getDeclaringClass) |  |
+| [hashCode()](#hashCode) |  |
+| [name()](#name) |  |
+| [notify()](#notify) |  |
+| [notifyAll()](#notifyAll) |  |
+| [ordinal()](#ordinal) |  |
+| [toString()](#toString) |  |
+| [valueOf(String name)](#valueOf-java.lang.String) |  |
+| [values()](#values) |  |
+| [wait()](#wait) |  |
+| [wait(long arg0)](#wait-long) |  |
+| [wait(long arg0, int arg1)](#wait-long-int) |  |
+### Extralarge {#Extralarge}
+```
+public static final BubbleSize Extralarge
+```
+
+
+### Extrasmall {#Extrasmall}
+```
+public static final BubbleSize Extrasmall
+```
+
+
+### Large {#Large}
+```
+public static final BubbleSize Large
+```
+
+
+### Normal {#Normal}
+```
+public static final BubbleSize Normal
+```
+
+
+### Small {#Small}
+```
+public static final BubbleSize Small
+```
+
+
+### undefined {#undefined}
+```
+public static final BubbleSize undefined
+```
+
+
+### <T>valueOf(Class<T> arg0, String arg1) {#-T-valueOf-java.lang.Class-T--java.lang.String}
+```
+public static T <T>valueOf(Class<T> arg0, String arg1)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | java.lang.Class<T> |  |
+| arg1 | java.lang.String |  |
+
+**Returns:**
+T
+### compareTo(E arg0) {#compareTo-E}
+```
+public final int compareTo(E arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | E |  |
+
+**Returns:**
+int
+### equals(Object arg0) {#equals-java.lang.Object}
+```
+public final boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getDeclaringClass() {#getDeclaringClass}
+```
+public final Class<E> getDeclaringClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<E>
+### hashCode() {#hashCode}
+```
+public final int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### name() {#name}
+```
+public final String name()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### notify() {#notify}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### ordinal() {#ordinal}
+```
+public final int ordinal()
+```
+
+
+
+
+**Returns:**
+int
+### toString() {#toString}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### valueOf(String name) {#valueOf-java.lang.String}
+```
+public static BubbleSize valueOf(String name)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 名前 | java.lang.String |  |
+
+**Returns:**
+[BubbleSize](../../com.aspose.omr/bubblesize/)
+### values() {#values}
+```
+public static BubbleSize[] values()
+```
+
+
+
+
+**Returns:**
+com.aspose.omr.BubbleSize[]
+### wait() {#wait}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/japanese/java/com.aspose.omr/choiceboxelement/_index.md
+++ b/japanese/java/com.aspose.omr/choiceboxelement/_index.md
@@ -1,0 +1,490 @@
+---
+title: "ChoiceBoxElement"
+second_title: "Aspose.OMR for Java API リファレンス"
+description: "ChoiceBox 質問を表します"
+type: docs
+weight: 11
+url: /ja/java/com.aspose.omr/choiceboxelement/
+---
+
+**Inheritance:**
+java.lang.Object, [com.aspose.omr.OmrElement](../../com.aspose.omr/omrelement/)
+```
+public class ChoiceBoxElement extends OmrElement
+```
+
+ChoiceBox 質問を表します
+## コンストラクタ
+
+| コンストラクタ | 説明 |
+| --- | --- |
+| [ChoiceBoxElement()](#ChoiceBoxElement) | 新しいインスタンスを初期化します [ChoiceBoxElement](../../com.aspose.omr/choiceboxelement/) クラス |
+## フィールド
+
+| フィールド | 説明 |
+| --- | --- |
+| [ElementType](#ElementType) |  |
+## メソッド
+
+| メソッド | 説明 |
+| --- | --- |
+| [addBubble(String name, int width, int height, int top, int left, boolean isValid)](#addBubble-java.lang.String-int-int-int-int-boolean) | 質問内にバブルを追加します |
+| [equals(Object arg0)](#equals-java.lang.Object) |  |
+| [getBubbleHeight()](#getBubbleHeight) |  |
+| [getBubbleWidth()](#getBubbleWidth) |  |
+| [getBubbles()](#getBubbles) | バブルコレクションを取得または設定します |
+| [getClass()](#getClass) |  |
+| [getHeight()](#getHeight) | 質問の高さを取得または設定します |
+| [getLeft()](#getLeft) | 質問の左位置を取得または設定します |
+| [getMultipleSelectionAllowed()](#getMultipleSelectionAllowed) | 複数選択が許可されているかどうかを示す値を取得または設定します |
+| [getName()](#getName) | 質問名を取得します |
+| [getOrientation()](#getOrientation) |  |
+| [getOrientationString()](#getOrientationString) | orientation プロパティの文字列表現を取得します |
+| [getRect()](#getRect) |  |
+| [getTop()](#getTop) | 質問の上位置を取得または設定します |
+| [getWidth()](#getWidth) | 質問の幅を取得または設定します |
+| [hashCode()](#hashCode) |  |
+| [isAlignedHorizontal()](#isAlignedHorizontal) | バブルが水平に配置されているかどうかを示す値を取得または設定します |
+| [isAlignedVertical()](#isAlignedVertical) | バブルが垂直に配置されているかどうかを示す値を取得または設定します |
+| [notify()](#notify) |  |
+| [notifyAll()](#notifyAll) |  |
+| [setAlignedHorizontal(boolean value)](#setAlignedHorizontal-boolean) | バブルが水平に配置されているかどうかを示す値を取得または設定します |
+| [setAlignedVertical(boolean value)](#setAlignedVertical-boolean) | バブルが垂直に配置されているかどうかを示す値を取得または設定します |
+| [setBubbleHeight(double value)](#setBubbleHeight-double) |  |
+| [setBubbleWidth(double value)](#setBubbleWidth-double) |  |
+| [setBubbles(System.Collections.Generic.List<OmrBubble> value)](#setBubbles-com.aspose.ms.System.Collections.Generic.List-com.aspose.omr.OmrBubble) | バブルコレクションを取得または設定します |
+| [setHeight(double value)](#setHeight-double) | 質問の高さを取得または設定します |
+| [setLeft(double value)](#setLeft-double) | 質問の左位置を取得または設定します |
+| [setMultipleSelectionAllowed(boolean value)](#setMultipleSelectionAllowed-boolean) | 複数選択が許可されているかどうかを示す値を取得または設定します |
+| [setName(String value)](#setName-java.lang.String) | 質問名を設定します |
+| [setOrientation(int value)](#setOrientation-int) |  |
+| [setTop(double value)](#setTop-double) | 質問の上位置を取得または設定します |
+| [setWidth(double value)](#setWidth-double) | 質問の幅を取得または設定します |
+| [toString()](#toString) |  |
+| [wait()](#wait) |  |
+| [wait(long arg0)](#wait-long) |  |
+| [wait(long arg0, int arg1)](#wait-long-int) |  |
+### ChoiceBoxElement() {#ChoiceBoxElement}
+```
+public ChoiceBoxElement()
+```
+
+
+新しいインスタンスを初期化します [ChoiceBoxElement](../../com.aspose.omr/choiceboxelement/) クラス
+
+### ElementType {#ElementType}
+```
+public String ElementType
+```
+
+
+### addBubble(String name, int width, int height, int top, int left, boolean isValid) {#addBubble-java.lang.String-int-int-int-int-boolean}
+```
+public final void addBubble(String name, int width, int height, int top, int left, boolean isValid)
+```
+
+
+質問内にバブルを追加します
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 名前 | java.lang.String | バブル名 |
+| 幅 | int | バブル幅 |
+| 高さ | int | バブル高さ |
+| 上 | int | バブルの上位置 |
+| 左 | int | バブルの左位置 |
+| isValid | boolean | バブル有効フラグ |
+
+### equals(Object arg0) {#equals-java.lang.Object}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getBubbleHeight() {#getBubbleHeight}
+```
+public final double getBubbleHeight()
+```
+
+
+
+
+**Returns:**
+double
+### getBubbleWidth() {#getBubbleWidth}
+```
+public final double getBubbleWidth()
+```
+
+
+
+
+**Returns:**
+double
+### getBubbles() {#getBubbles}
+```
+public final System.Collections.Generic.List<OmrBubble> getBubbles()
+```
+
+
+バブルコレクションを取得または設定します
+
+**Returns:**
+com.aspose.ms.System.Collections.Generic.List<com.aspose.omr.OmrBubble> - バブルコレクション
+### getClass() {#getClass}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getHeight() {#getHeight}
+```
+public final double getHeight()
+```
+
+
+質問の高さを取得または設定します
+
+**Returns:**
+double - 高さ
+### getLeft() {#getLeft}
+```
+public final double getLeft()
+```
+
+
+質問の左位置を取得または設定します
+
+**Returns:**
+double - 左
+### getMultipleSelectionAllowed() {#getMultipleSelectionAllowed}
+```
+public final boolean getMultipleSelectionAllowed()
+```
+
+
+複数選択が許可されているかどうかを示す値を取得または設定します
+
+**Returns:**
+boolean - 複数選択が許可されているかどうかを示す値
+### getName() {#getName}
+```
+public final String getName()
+```
+
+
+質問名を取得します
+
+**Returns:**
+java.lang.String - 質問名
+### getOrientation() {#getOrientation}
+```
+public final int getOrientation()
+```
+
+
+
+
+**Returns:**
+int
+### getOrientationString() {#getOrientationString}
+```
+public final String getOrientationString()
+```
+
+
+orientation プロパティの文字列表現を取得します
+
+**Returns:**
+java.lang.String - orientation プロパティの文字列表現
+### getRect() {#getRect}
+```
+public System.Drawing.RectangleF getRect()
+```
+
+
+
+
+**Returns:**
+com.aspose.ms.System.Drawing.RectangleF
+### getTop() {#getTop}
+```
+public final double getTop()
+```
+
+
+質問の上位置を取得または設定します
+
+**Returns:**
+double - 上
+### getWidth() {#getWidth}
+```
+public final double getWidth()
+```
+
+
+質問の幅を取得または設定します
+
+**Returns:**
+double - 幅
+### hashCode() {#hashCode}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### isAlignedHorizontal() {#isAlignedHorizontal}
+```
+public final boolean isAlignedHorizontal()
+```
+
+
+バブルが水平に配置されているかどうかを示す値を取得または設定します
+
+**Returns:**
+boolean - バブルが水平に配置されているかどうかを示す値
+### isAlignedVertical() {#isAlignedVertical}
+```
+public final boolean isAlignedVertical()
+```
+
+
+バブルが垂直に配置されているかどうかを示す値を取得または設定します
+
+**Returns:**
+boolean - バブルが垂直に配置されているかどうかを示す値
+### notify() {#notify}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setAlignedHorizontal(boolean value) {#setAlignedHorizontal-boolean}
+```
+public final void setAlignedHorizontal(boolean value)
+```
+
+
+バブルが水平に配置されているかどうかを示す値を取得または設定します
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | boolean | バブルが水平に配置されているかどうかを示す値 |
+
+### setAlignedVertical(boolean value) {#setAlignedVertical-boolean}
+```
+public final void setAlignedVertical(boolean value)
+```
+
+
+バブルが垂直に配置されているかどうかを示す値を取得または設定します
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | boolean | バブルが垂直に配置されているかどうかを示す値 |
+
+### setBubbleHeight(double value) {#setBubbleHeight-double}
+```
+public final void setBubbleHeight(double value)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | double |  |
+
+### setBubbleWidth(double value) {#setBubbleWidth-double}
+```
+public final void setBubbleWidth(double value)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | double |  |
+
+### setBubbles(System.Collections.Generic.List<OmrBubble> value) {#setBubbles-com.aspose.ms.System.Collections.Generic.List-com.aspose.omr.OmrBubble}
+```
+public final void setBubbles(System.Collections.Generic.List<OmrBubble> value)
+```
+
+
+バブルコレクションを取得または設定します
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | com.aspose.ms.System.Collections.Generic.List<com.aspose.omr.OmrBubble> | バブルコレクション |
+
+### setHeight(double value) {#setHeight-double}
+```
+public final void setHeight(double value)
+```
+
+
+質問の高さを取得または設定します
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | double | 高さ |
+
+### setLeft(double value) {#setLeft-double}
+```
+public final void setLeft(double value)
+```
+
+
+質問の左位置を取得または設定します
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | double | 左 |
+
+### setMultipleSelectionAllowed(boolean value) {#setMultipleSelectionAllowed-boolean}
+```
+public final void setMultipleSelectionAllowed(boolean value)
+```
+
+
+複数選択が許可されているかどうかを示す値を取得または設定します
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | boolean | 複数選択が許可されているかどうかを示す値 |
+
+### setName(String value) {#setName-java.lang.String}
+```
+public final void setName(String value)
+```
+
+
+質問名を設定します
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | java.lang.String | 質問名 |
+
+### setOrientation(int value) {#setOrientation-int}
+```
+public final void setOrientation(int value)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | int |  |
+
+### setTop(double value) {#setTop-double}
+```
+public final void setTop(double value)
+```
+
+
+質問の上位置を取得または設定します
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | double | 上 |
+
+### setWidth(double value) {#setWidth-double}
+```
+public final void setWidth(double value)
+```
+
+
+質問の幅を取得または設定します
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | double | 幅 |
+
+### toString() {#toString}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/japanese/java/com.aspose.omr/clipareaelement/_index.md
+++ b/japanese/java/com.aspose.omr/clipareaelement/_index.md
@@ -1,0 +1,297 @@
+---
+title: "ClipAreaElement"
+second_title: "Aspose.OMR for Java API リファレンス"
+description: "クリップ領域要素を表します"
+type: docs
+weight: 12
+url: /ja/java/com.aspose.omr/clipareaelement/
+---
+
+**Inheritance:**
+java.lang.Object, [com.aspose.omr.OmrElement](../../com.aspose.omr/omrelement/)
+```
+public class ClipAreaElement extends OmrElement
+```
+
+クリップ領域要素を表します
+## コンストラクタ
+
+| コンストラクタ | 説明 |
+| --- | --- |
+| [ClipAreaElement()](#ClipAreaElement) |  |
+## メソッド
+
+| メソッド | 説明 |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object) |  |
+| [getClass()](#getClass) |  |
+| [getHeight()](#getHeight) | 質問の高さを取得または設定します |
+| [getJpegQuality()](#getJpegQuality) |  |
+| [getLeft()](#getLeft) | 質問の左位置を取得または設定します |
+| [getName()](#getName) | 質問名を取得します |
+| [getRect()](#getRect) |  |
+| [getTop()](#getTop) | 質問の上位置を取得または設定します |
+| [getWidth()](#getWidth) | 質問の幅を取得または設定します |
+| [hashCode()](#hashCode) |  |
+| [notify()](#notify) |  |
+| [notifyAll()](#notifyAll) |  |
+| [setHeight(double value)](#setHeight-double) | 質問の高さを取得または設定します |
+| [setJpegQuality(int value)](#setJpegQuality-int) |  |
+| [setLeft(double value)](#setLeft-double) | 質問の左位置を取得または設定します |
+| [setName(String value)](#setName-java.lang.String) | 質問名を設定します |
+| [setTop(double value)](#setTop-double) | 質問の上位置を取得または設定します |
+| [setWidth(double value)](#setWidth-double) | 質問の幅を取得または設定します |
+| [toString()](#toString) |  |
+| [wait()](#wait) |  |
+| [wait(long arg0)](#wait-long) |  |
+| [wait(long arg0, int arg1)](#wait-long-int) |  |
+### ClipAreaElement() {#ClipAreaElement}
+```
+public ClipAreaElement()
+```
+
+
+### equals(Object arg0) {#equals-java.lang.Object}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getHeight() {#getHeight}
+```
+public final double getHeight()
+```
+
+
+質問の高さを取得または設定します
+
+**Returns:**
+double - 高さ
+### getJpegQuality() {#getJpegQuality}
+```
+public final int getJpegQuality()
+```
+
+
+
+
+**Returns:**
+int
+### getLeft() {#getLeft}
+```
+public final double getLeft()
+```
+
+
+質問の左位置を取得または設定します
+
+**Returns:**
+double - 左
+### getName() {#getName}
+```
+public final String getName()
+```
+
+
+質問名を取得します
+
+**Returns:**
+java.lang.String - 質問名
+### getRect() {#getRect}
+```
+public System.Drawing.RectangleF getRect()
+```
+
+
+
+
+**Returns:**
+com.aspose.ms.System.Drawing.RectangleF
+### getTop() {#getTop}
+```
+public final double getTop()
+```
+
+
+質問の上位置を取得または設定します
+
+**Returns:**
+double - 上
+### getWidth() {#getWidth}
+```
+public final double getWidth()
+```
+
+
+質問の幅を取得または設定します
+
+**Returns:**
+double - 幅
+### hashCode() {#hashCode}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setHeight(double value) {#setHeight-double}
+```
+public final void setHeight(double value)
+```
+
+
+質問の高さを取得または設定します
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | double | 高さ |
+
+### setJpegQuality(int value) {#setJpegQuality-int}
+```
+public final void setJpegQuality(int value)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | int |  |
+
+### setLeft(double value) {#setLeft-double}
+```
+public final void setLeft(double value)
+```
+
+
+質問の左位置を取得または設定します
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | double | 左 |
+
+### setName(String value) {#setName-java.lang.String}
+```
+public final void setName(String value)
+```
+
+
+質問名を設定します
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | java.lang.String | 質問名 |
+
+### setTop(double value) {#setTop-double}
+```
+public final void setTop(double value)
+```
+
+
+質問の上位置を取得または設定します
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | double | 上 |
+
+### setWidth(double value) {#setWidth-double}
+```
+public final void setWidth(double value)
+```
+
+
+質問の幅を取得または設定します
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | double | 幅 |
+
+### toString() {#toString}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/japanese/java/com.aspose.omr/drawingcolor/_index.md
+++ b/japanese/java/com.aspose.omr/drawingcolor/_index.md
@@ -1,0 +1,1507 @@
+---
+title: "DrawingColor"
+second_title: "Aspose.OMR for Java API リファレンス"
+description: "テンプレート生成で使用される色"
+type: docs
+weight: 35
+url: /ja/java/com.aspose.omr/drawingcolor/
+---
+
+**Inheritance:**
+java.lang.Object, java.lang.Enum
+```
+public enum DrawingColor extends Enum<DrawingColor>
+```
+
+テンプレート生成で使用される色
+## フィールド
+
+| フィールド | 説明 |
+| --- | --- |
+| [AliceBlue](#AliceBlue) | AliceBlue カラー |
+| [AntiqueWhite](#AntiqueWhite) | AntiqueWhite 色。 |
+| [Aqua](#Aqua) | Aqua 色。 |
+| [Aquamarine](#Aquamarine) | Aquamarine 色 |
+| [Azure](#Azure) | Azure 色。 |
+| [Beige](#Beige) | Beige 色。 |
+| [Bisque](#Bisque) | Bisque 色。 |
+| [Black](#Black) | Black 色。 |
+| [BlanchedAlmond](#BlanchedAlmond) | BlanchedAlmond 色。 |
+| [Blue](#Blue) | Blue 色。 |
+| [BlueViolet](#BlueViolet) | BlueViolet 色 |
+| [Brown](#Brown) | Brown 色 |
+| [BurlyWood](#BurlyWood) | BurlyWood 色 |
+| [CadetBlue](#CadetBlue) | CadetBlue 色 |
+| [Chartreuse](#Chartreuse) | Chartreuse 色 |
+| [Chocolate](#Chocolate) | Chocolate 色 |
+| [Coral](#Coral) | Coral 色 |
+| [CornflowerBlue](#CornflowerBlue) | CornflowerBlue 色 |
+| [Cornsilk](#Cornsilk) | Cornsilk 色 |
+| [Crimson](#Crimson) | Crimson 色 |
+| [Cyan](#Cyan) | Cyan 色 |
+| [DarkBlue](#DarkBlue) | DarkBlue 色 |
+| [DarkCyan](#DarkCyan) | DarkCyan 色 |
+| [DarkGoldenrod](#DarkGoldenrod) | DarkGoldenrod 色 |
+| [DarkGray](#DarkGray) | DarkGray 色 |
+| [DarkGreen](#DarkGreen) | DarkGreen 色 |
+| [DarkKhaki](#DarkKhaki) | DarkKhaki 色 |
+| [DarkMagenta](#DarkMagenta) | DarkMagenta 色 |
+| [DarkOliveGreen](#DarkOliveGreen) | DarkOliveGreen 色 |
+| [DarkOrange](#DarkOrange) | DarkOrange 色 |
+| [DarkOrchid](#DarkOrchid) | DarkOrchid 色 |
+| [DarkRed](#DarkRed) | DarkRed 色 |
+| [DarkSalmon](#DarkSalmon) | DarkSalmon 色 |
+| [DarkSeaGreen](#DarkSeaGreen) | DarkSeaGreen 色 |
+| [DarkSlateBlue](#DarkSlateBlue) | DarkSlateBlue 色 |
+| [DarkSlateGray](#DarkSlateGray) | DarkSlateGray 色 |
+| [DarkTurquoise](#DarkTurquoise) | DarkTurquoise 色 |
+| [DarkViolet](#DarkViolet) | DarkViolet 色 |
+| [DeepPink](#DeepPink) | DeepPink 色 |
+| [DeepSkyBlue](#DeepSkyBlue) | DeepSkyBlue 色 |
+| [DimGray](#DimGray) | DimGray 色 |
+| [DodgerBlue](#DodgerBlue) | DodgerBlue 色 |
+| [Firebrick](#Firebrick) | Firebrick 色 |
+| [FloralWhite](#FloralWhite) | FloralWhite 色 |
+| [ForestGreen](#ForestGreen) | ForestGreen 色 |
+| [Fuchsia](#Fuchsia) | Fuchsia 色 |
+| [Gainsboro](#Gainsboro) | Gainsboro 色 |
+| [GhostWhite](#GhostWhite) | GhostWhite 色 |
+| [Gold](#Gold) | Gold 色 |
+| [Goldenrod](#Goldenrod) | Goldenrod 色 |
+| [Gray](#Gray) | Gray 色 |
+| [Green](#Green) | 緑色 |
+| [GreenYellow](#GreenYellow) | 黄緑色 |
+| [Honeydew](#Honeydew) | ハニーデュー色 |
+| [HotPink](#HotPink) | ホットピンク色 |
+| [IndianRed](#IndianRed) | インディアンレッド色 |
+| [Indigo](#Indigo) | 藍色 |
+| [Ivory](#Ivory) | アイボリー色 |
+| [Khaki](#Khaki) | カーキ色 |
+| [Lavender](#Lavender) | ラベンダー色 |
+| [LavenderBlush](#LavenderBlush) | ラベンダーブラッシュ色 |
+| [LawnGreen](#LawnGreen) | ローングリーン色 |
+| [LemonChiffon](#LemonChiffon) | レモンシフォン色 |
+| [LightBlue](#LightBlue) | ライトブルー色 |
+| [LightCoral](#LightCoral) | ライトコーラル色 |
+| [LightCyan](#LightCyan) | ライトシアン色 |
+| [LightGoldenrodYellow](#LightGoldenrodYellow) | ライトゴールデンロッドイエロー色 |
+| [LightGray](#LightGray) | ライトグレー色 |
+| [LightGreen](#LightGreen) | ライトグリーン色 |
+| [LightPink](#LightPink) | ライトピンク色 |
+| [LightSalmon](#LightSalmon) | ライトサーモン色 |
+| [LightSeaGreen](#LightSeaGreen) | ライトシーグリーン色 |
+| [LightSkyBlue](#LightSkyBlue) | ライトスカイブルー色 |
+| [LightSlateGray](#LightSlateGray) | ライトスレートグレー色 |
+| [LightSteelBlue](#LightSteelBlue) | ライトスチールブルー色 |
+| [LightYellow](#LightYellow) | ライトイエロー色 |
+| [Lime](#Lime) | ライム色 |
+| [LimeGreen](#LimeGreen) | ライムグリーン色 |
+| [Linen](#Linen) | リネン色 |
+| [Magenta](#Magenta) | マゼンタ色 |
+| [Maroon](#Maroon) | マルーン色 |
+| [MediumAquamarine](#MediumAquamarine) | ミディアムアクアマリン色 |
+| [MediumBlue](#MediumBlue) | ミディアムブルー色 |
+| [MediumOrchid](#MediumOrchid) | ミディアムオーキッド色 |
+| [MediumPurple](#MediumPurple) | ミディアムパープル色 |
+| [MediumSeaGreen](#MediumSeaGreen) | ミディアムシーグリーン色 |
+| [MediumSlateBlue](#MediumSlateBlue) | ミディアムスレートブルー色 |
+| [MediumSpringGreen](#MediumSpringGreen) | ミディアムスプリンググリーン色 |
+| [MediumTurquoise](#MediumTurquoise) | ミディアムターコイズ色 |
+| [MediumVioletRed](#MediumVioletRed) | ミディアムバイオレットレッド色 |
+| [MidnightBlue](#MidnightBlue) | ミッドナイトブルー色 |
+| [MintCream](#MintCream) | ミントクリーム色 |
+| [MistyRose](#MistyRose) | ミスティーローズ色 |
+| [Moccasin](#Moccasin) | モカシン色 |
+| [NavajoWhite](#NavajoWhite) | ナバホホワイト色 |
+| [Navy](#Navy) | ネイビー色 |
+| [OldLace](#OldLace) | オールドレース色 |
+| [Olive](#Olive) | オリーブ色 |
+| [OliveDrab](#OliveDrab) | オリーブドラブ色 |
+| [Orange](#Orange) | オレンジ色 |
+| [OrangeRed](#OrangeRed) | オレンジレッド色 |
+| [Orchid](#Orchid) | ラン 色 |
+| [PaleGoldenrod](#PaleGoldenrod) | 淡いゴールデンロッド 色 |
+| [PaleGreen](#PaleGreen) | 淡い緑 色 |
+| [PaleTurquoise](#PaleTurquoise) | 淡いターコイズ 色 |
+| [PaleVioletRed](#PaleVioletRed) | 淡いバイオレットレッド 色 |
+| [PapayaWhip](#PapayaWhip) | パパイヤウィップ 色 |
+| [PeachPuff](#PeachPuff) | ピーチパフ 色 |
+| [Peru](#Peru) | ペルー 色 |
+| [Pink](#Pink) | ピンク 色 |
+| [Plum](#Plum) | プラム 色 |
+| [PowderBlue](#PowderBlue) | パウダーブルー 色 |
+| [Purple](#Purple) | 紫 色 |
+| [Red](#Red) | 赤 色 タイプ |
+| [RosyBrown](#RosyBrown) | ロージーブラウン 色 |
+| [RoyalBlue](#RoyalBlue) | ロイヤルブルー 色 |
+| [SaddleBrown](#SaddleBrown) | サドルブラウン 色 |
+| [Salmon](#Salmon) | サーモン 色 |
+| [SandyBrown](#SandyBrown) | サンディーブラウン 色 |
+| [SeaGreen](#SeaGreen) | シーグリーン 色 |
+| [SeaShell](#SeaShell) | シーシェル 色 |
+| [Sienna](#Sienna) | シエナ 色 |
+| [Silver](#Silver) | シルバー 色 |
+| [SkyBlue](#SkyBlue) | スカイブルー 色 |
+| [SlateBlue](#SlateBlue) | スレートブルー 色 |
+| [SlateGray](#SlateGray) | スレートグレー 色 |
+| [Snow](#Snow) | スノー色 |
+| [SpringGreen](#SpringGreen) | スプリンググリーン色 |
+| [SteelBlue](#SteelBlue) | スチールブルー色 |
+| [Tan](#Tan) | タン色タイプ |
+| [Teal](#Teal) | ティール色 |
+| [Thistle](#Thistle) | シスル色 |
+| [Tomato](#Tomato) | トマト色 |
+| [Turquoise](#Turquoise) | ターコイズ色 |
+| [Violet](#Violet) | バイオレット色 |
+| [Wheat](#Wheat) | ウィート色 |
+| [White](#White) | 白色 |
+| [WhiteSmoke](#WhiteSmoke) | ホワイトスモーク色 |
+| [Yellow](#Yellow) | 黄色 |
+| [YellowGreen](#YellowGreen) | 黄緑色 |
+| [undefined](#undefined) | 未定義の色です。 |
+## メソッド
+
+| メソッド | 説明 |
+| --- | --- |
+| [<T>valueOf(Class<T> arg0, String arg1)](#-T-valueOf-java.lang.Class-T--java.lang.String) |  |
+| [ToSystem(DrawingColor color)](#ToSystem-com.aspose.omr.DrawingColor) |  |
+| [compareTo(E arg0)](#compareTo-E) |  |
+| [equals(Object arg0)](#equals-java.lang.Object) |  |
+| [getClass()](#getClass) |  |
+| [getDeclaringClass()](#getDeclaringClass) |  |
+| [hashCode()](#hashCode) |  |
+| [name()](#name) |  |
+| [notify()](#notify) |  |
+| [notifyAll()](#notifyAll) |  |
+| [ordinal()](#ordinal) |  |
+| [toString()](#toString) |  |
+| [valueOf(String name)](#valueOf-java.lang.String) |  |
+| [values()](#values) |  |
+| [wait()](#wait) |  |
+| [wait(long arg0)](#wait-long) |  |
+| [wait(long arg0, int arg1)](#wait-long-int) |  |
+### AliceBlue {#AliceBlue}
+```
+public static final DrawingColor AliceBlue
+```
+
+
+AliceBlue カラー
+
+### AntiqueWhite {#AntiqueWhite}
+```
+public static final DrawingColor AntiqueWhite
+```
+
+
+AntiqueWhite 色。
+
+### Aqua {#Aqua}
+```
+public static final DrawingColor Aqua
+```
+
+
+Aqua 色。
+
+### Aquamarine {#Aquamarine}
+```
+public static final DrawingColor Aquamarine
+```
+
+
+Aquamarine 色
+
+### Azure {#Azure}
+```
+public static final DrawingColor Azure
+```
+
+
+Azure 色。
+
+### Beige {#Beige}
+```
+public static final DrawingColor Beige
+```
+
+
+Beige 色。
+
+### Bisque {#Bisque}
+```
+public static final DrawingColor Bisque
+```
+
+
+Bisque 色。
+
+### Black {#Black}
+```
+public static final DrawingColor Black
+```
+
+
+Black 色。
+
+### BlanchedAlmond {#BlanchedAlmond}
+```
+public static final DrawingColor BlanchedAlmond
+```
+
+
+BlanchedAlmond 色。
+
+### Blue {#Blue}
+```
+public static final DrawingColor Blue
+```
+
+
+Blue 色。
+
+### BlueViolet {#BlueViolet}
+```
+public static final DrawingColor BlueViolet
+```
+
+
+BlueViolet 色
+
+### Brown {#Brown}
+```
+public static final DrawingColor Brown
+```
+
+
+Brown 色
+
+### BurlyWood {#BurlyWood}
+```
+public static final DrawingColor BurlyWood
+```
+
+
+BurlyWood 色
+
+### CadetBlue {#CadetBlue}
+```
+public static final DrawingColor CadetBlue
+```
+
+
+CadetBlue 色
+
+### Chartreuse {#Chartreuse}
+```
+public static final DrawingColor Chartreuse
+```
+
+
+Chartreuse 色
+
+### Chocolate {#Chocolate}
+```
+public static final DrawingColor Chocolate
+```
+
+
+Chocolate 色
+
+### Coral {#Coral}
+```
+public static final DrawingColor Coral
+```
+
+
+Coral 色
+
+### CornflowerBlue {#CornflowerBlue}
+```
+public static final DrawingColor CornflowerBlue
+```
+
+
+CornflowerBlue 色
+
+### Cornsilk {#Cornsilk}
+```
+public static final DrawingColor Cornsilk
+```
+
+
+Cornsilk 色
+
+### Crimson {#Crimson}
+```
+public static final DrawingColor Crimson
+```
+
+
+Crimson 色
+
+### Cyan {#Cyan}
+```
+public static final DrawingColor Cyan
+```
+
+
+Cyan 色
+
+### DarkBlue {#DarkBlue}
+```
+public static final DrawingColor DarkBlue
+```
+
+
+DarkBlue 色
+
+### DarkCyan {#DarkCyan}
+```
+public static final DrawingColor DarkCyan
+```
+
+
+DarkCyan 色
+
+### DarkGoldenrod {#DarkGoldenrod}
+```
+public static final DrawingColor DarkGoldenrod
+```
+
+
+DarkGoldenrod 色
+
+### DarkGray {#DarkGray}
+```
+public static final DrawingColor DarkGray
+```
+
+
+DarkGray 色
+
+### DarkGreen {#DarkGreen}
+```
+public static final DrawingColor DarkGreen
+```
+
+
+DarkGreen 色
+
+### DarkKhaki {#DarkKhaki}
+```
+public static final DrawingColor DarkKhaki
+```
+
+
+DarkKhaki 色
+
+### DarkMagenta {#DarkMagenta}
+```
+public static final DrawingColor DarkMagenta
+```
+
+
+DarkMagenta 色
+
+### DarkOliveGreen {#DarkOliveGreen}
+```
+public static final DrawingColor DarkOliveGreen
+```
+
+
+DarkOliveGreen 色
+
+### DarkOrange {#DarkOrange}
+```
+public static final DrawingColor DarkOrange
+```
+
+
+DarkOrange 色
+
+### DarkOrchid {#DarkOrchid}
+```
+public static final DrawingColor DarkOrchid
+```
+
+
+DarkOrchid 色
+
+### DarkRed {#DarkRed}
+```
+public static final DrawingColor DarkRed
+```
+
+
+DarkRed 色
+
+### DarkSalmon {#DarkSalmon}
+```
+public static final DrawingColor DarkSalmon
+```
+
+
+DarkSalmon 色
+
+### DarkSeaGreen {#DarkSeaGreen}
+```
+public static final DrawingColor DarkSeaGreen
+```
+
+
+DarkSeaGreen 色
+
+### DarkSlateBlue {#DarkSlateBlue}
+```
+public static final DrawingColor DarkSlateBlue
+```
+
+
+DarkSlateBlue 色
+
+### DarkSlateGray {#DarkSlateGray}
+```
+public static final DrawingColor DarkSlateGray
+```
+
+
+DarkSlateGray 色
+
+### DarkTurquoise {#DarkTurquoise}
+```
+public static final DrawingColor DarkTurquoise
+```
+
+
+DarkTurquoise 色
+
+### DarkViolet {#DarkViolet}
+```
+public static final DrawingColor DarkViolet
+```
+
+
+DarkViolet 色
+
+### DeepPink {#DeepPink}
+```
+public static final DrawingColor DeepPink
+```
+
+
+DeepPink 色
+
+### DeepSkyBlue {#DeepSkyBlue}
+```
+public static final DrawingColor DeepSkyBlue
+```
+
+
+DeepSkyBlue 色
+
+### DimGray {#DimGray}
+```
+public static final DrawingColor DimGray
+```
+
+
+DimGray 色
+
+### DodgerBlue {#DodgerBlue}
+```
+public static final DrawingColor DodgerBlue
+```
+
+
+DodgerBlue 色
+
+### Firebrick {#Firebrick}
+```
+public static final DrawingColor Firebrick
+```
+
+
+Firebrick 色
+
+### FloralWhite {#FloralWhite}
+```
+public static final DrawingColor FloralWhite
+```
+
+
+FloralWhite 色
+
+### ForestGreen {#ForestGreen}
+```
+public static final DrawingColor ForestGreen
+```
+
+
+ForestGreen 色
+
+### Fuchsia {#Fuchsia}
+```
+public static final DrawingColor Fuchsia
+```
+
+
+Fuchsia 色
+
+### Gainsboro {#Gainsboro}
+```
+public static final DrawingColor Gainsboro
+```
+
+
+Gainsboro 色
+
+### GhostWhite {#GhostWhite}
+```
+public static final DrawingColor GhostWhite
+```
+
+
+GhostWhite 色
+
+### Gold {#Gold}
+```
+public static final DrawingColor Gold
+```
+
+
+Gold 色
+
+### Goldenrod {#Goldenrod}
+```
+public static final DrawingColor Goldenrod
+```
+
+
+Goldenrod 色
+
+### Gray {#Gray}
+```
+public static final DrawingColor Gray
+```
+
+
+Gray 色
+
+### Green {#Green}
+```
+public static final DrawingColor Green
+```
+
+
+緑色
+
+### GreenYellow {#GreenYellow}
+```
+public static final DrawingColor GreenYellow
+```
+
+
+黄緑色
+
+### Honeydew {#Honeydew}
+```
+public static final DrawingColor Honeydew
+```
+
+
+ハニーデュー色
+
+### HotPink {#HotPink}
+```
+public static final DrawingColor HotPink
+```
+
+
+ホットピンク色
+
+### IndianRed {#IndianRed}
+```
+public static final DrawingColor IndianRed
+```
+
+
+インディアンレッド色
+
+### Indigo {#Indigo}
+```
+public static final DrawingColor Indigo
+```
+
+
+藍色
+
+### Ivory {#Ivory}
+```
+public static final DrawingColor Ivory
+```
+
+
+アイボリー色
+
+### Khaki {#Khaki}
+```
+public static final DrawingColor Khaki
+```
+
+
+カーキ色
+
+### Lavender {#Lavender}
+```
+public static final DrawingColor Lavender
+```
+
+
+ラベンダー色
+
+### LavenderBlush {#LavenderBlush}
+```
+public static final DrawingColor LavenderBlush
+```
+
+
+ラベンダーブラッシュ色
+
+### LawnGreen {#LawnGreen}
+```
+public static final DrawingColor LawnGreen
+```
+
+
+ローングリーン色
+
+### LemonChiffon {#LemonChiffon}
+```
+public static final DrawingColor LemonChiffon
+```
+
+
+レモンシフォン色
+
+### LightBlue {#LightBlue}
+```
+public static final DrawingColor LightBlue
+```
+
+
+ライトブルー色
+
+### LightCoral {#LightCoral}
+```
+public static final DrawingColor LightCoral
+```
+
+
+ライトコーラル色
+
+### LightCyan {#LightCyan}
+```
+public static final DrawingColor LightCyan
+```
+
+
+ライトシアン色
+
+### LightGoldenrodYellow {#LightGoldenrodYellow}
+```
+public static final DrawingColor LightGoldenrodYellow
+```
+
+
+ライトゴールデンロッドイエロー色
+
+### LightGray {#LightGray}
+```
+public static final DrawingColor LightGray
+```
+
+
+ライトグレー色
+
+### LightGreen {#LightGreen}
+```
+public static final DrawingColor LightGreen
+```
+
+
+ライトグリーン色
+
+### LightPink {#LightPink}
+```
+public static final DrawingColor LightPink
+```
+
+
+ライトピンク色
+
+### LightSalmon {#LightSalmon}
+```
+public static final DrawingColor LightSalmon
+```
+
+
+ライトサーモン色
+
+### LightSeaGreen {#LightSeaGreen}
+```
+public static final DrawingColor LightSeaGreen
+```
+
+
+ライトシーグリーン色
+
+### LightSkyBlue {#LightSkyBlue}
+```
+public static final DrawingColor LightSkyBlue
+```
+
+
+ライトスカイブルー色
+
+### LightSlateGray {#LightSlateGray}
+```
+public static final DrawingColor LightSlateGray
+```
+
+
+ライトスレートグレー色
+
+### LightSteelBlue {#LightSteelBlue}
+```
+public static final DrawingColor LightSteelBlue
+```
+
+
+ライトスチールブルー色
+
+### LightYellow {#LightYellow}
+```
+public static final DrawingColor LightYellow
+```
+
+
+ライトイエロー色
+
+### Lime {#Lime}
+```
+public static final DrawingColor Lime
+```
+
+
+ライム色
+
+### LimeGreen {#LimeGreen}
+```
+public static final DrawingColor LimeGreen
+```
+
+
+ライムグリーン色
+
+### Linen {#Linen}
+```
+public static final DrawingColor Linen
+```
+
+
+リネン色
+
+### Magenta {#Magenta}
+```
+public static final DrawingColor Magenta
+```
+
+
+マゼンタ色
+
+### Maroon {#Maroon}
+```
+public static final DrawingColor Maroon
+```
+
+
+マルーン色
+
+### MediumAquamarine {#MediumAquamarine}
+```
+public static final DrawingColor MediumAquamarine
+```
+
+
+ミディアムアクアマリン色
+
+### MediumBlue {#MediumBlue}
+```
+public static final DrawingColor MediumBlue
+```
+
+
+ミディアムブルー色
+
+### MediumOrchid {#MediumOrchid}
+```
+public static final DrawingColor MediumOrchid
+```
+
+
+ミディアムオーキッド色
+
+### MediumPurple {#MediumPurple}
+```
+public static final DrawingColor MediumPurple
+```
+
+
+ミディアムパープル色
+
+### MediumSeaGreen {#MediumSeaGreen}
+```
+public static final DrawingColor MediumSeaGreen
+```
+
+
+ミディアムシーグリーン色
+
+### MediumSlateBlue {#MediumSlateBlue}
+```
+public static final DrawingColor MediumSlateBlue
+```
+
+
+ミディアムスレートブルー色
+
+### MediumSpringGreen {#MediumSpringGreen}
+```
+public static final DrawingColor MediumSpringGreen
+```
+
+
+ミディアムスプリンググリーン色
+
+### MediumTurquoise {#MediumTurquoise}
+```
+public static final DrawingColor MediumTurquoise
+```
+
+
+ミディアムターコイズ色
+
+### MediumVioletRed {#MediumVioletRed}
+```
+public static final DrawingColor MediumVioletRed
+```
+
+
+ミディアムバイオレットレッド色
+
+### MidnightBlue {#MidnightBlue}
+```
+public static final DrawingColor MidnightBlue
+```
+
+
+ミッドナイトブルー色
+
+### MintCream {#MintCream}
+```
+public static final DrawingColor MintCream
+```
+
+
+ミントクリーム色
+
+### MistyRose {#MistyRose}
+```
+public static final DrawingColor MistyRose
+```
+
+
+ミスティーローズ色
+
+### Moccasin {#Moccasin}
+```
+public static final DrawingColor Moccasin
+```
+
+
+モカシン色
+
+### NavajoWhite {#NavajoWhite}
+```
+public static final DrawingColor NavajoWhite
+```
+
+
+ナバホホワイト色
+
+### Navy {#Navy}
+```
+public static final DrawingColor Navy
+```
+
+
+ネイビー色
+
+### OldLace {#OldLace}
+```
+public static final DrawingColor OldLace
+```
+
+
+オールドレース色
+
+### Olive {#Olive}
+```
+public static final DrawingColor Olive
+```
+
+
+オリーブ色
+
+### OliveDrab {#OliveDrab}
+```
+public static final DrawingColor OliveDrab
+```
+
+
+オリーブドラブ色
+
+### Orange {#Orange}
+```
+public static final DrawingColor Orange
+```
+
+
+オレンジ色
+
+### OrangeRed {#OrangeRed}
+```
+public static final DrawingColor OrangeRed
+```
+
+
+オレンジレッド色
+
+### Orchid {#Orchid}
+```
+public static final DrawingColor Orchid
+```
+
+
+ラン 色
+
+### PaleGoldenrod {#PaleGoldenrod}
+```
+public static final DrawingColor PaleGoldenrod
+```
+
+
+淡いゴールデンロッド 色
+
+### PaleGreen {#PaleGreen}
+```
+public static final DrawingColor PaleGreen
+```
+
+
+淡い緑 色
+
+### PaleTurquoise {#PaleTurquoise}
+```
+public static final DrawingColor PaleTurquoise
+```
+
+
+淡いターコイズ 色
+
+### PaleVioletRed {#PaleVioletRed}
+```
+public static final DrawingColor PaleVioletRed
+```
+
+
+淡いバイオレットレッド 色
+
+### PapayaWhip {#PapayaWhip}
+```
+public static final DrawingColor PapayaWhip
+```
+
+
+パパイヤウィップ 色
+
+### PeachPuff {#PeachPuff}
+```
+public static final DrawingColor PeachPuff
+```
+
+
+ピーチパフ 色
+
+### Peru {#Peru}
+```
+public static final DrawingColor Peru
+```
+
+
+ペルー 色
+
+### Pink {#Pink}
+```
+public static final DrawingColor Pink
+```
+
+
+ピンク 色
+
+### Plum {#Plum}
+```
+public static final DrawingColor Plum
+```
+
+
+プラム 色
+
+### PowderBlue {#PowderBlue}
+```
+public static final DrawingColor PowderBlue
+```
+
+
+パウダーブルー 色
+
+### Purple {#Purple}
+```
+public static final DrawingColor Purple
+```
+
+
+紫 色
+
+### Red {#Red}
+```
+public static final DrawingColor Red
+```
+
+
+赤 色 タイプ
+
+### RosyBrown {#RosyBrown}
+```
+public static final DrawingColor RosyBrown
+```
+
+
+ロージーブラウン 色
+
+### RoyalBlue {#RoyalBlue}
+```
+public static final DrawingColor RoyalBlue
+```
+
+
+ロイヤルブルー 色
+
+### SaddleBrown {#SaddleBrown}
+```
+public static final DrawingColor SaddleBrown
+```
+
+
+サドルブラウン 色
+
+### Salmon {#Salmon}
+```
+public static final DrawingColor Salmon
+```
+
+
+サーモン 色
+
+### SandyBrown {#SandyBrown}
+```
+public static final DrawingColor SandyBrown
+```
+
+
+サンディーブラウン 色
+
+### SeaGreen {#SeaGreen}
+```
+public static final DrawingColor SeaGreen
+```
+
+
+シーグリーン 色
+
+### SeaShell {#SeaShell}
+```
+public static final DrawingColor SeaShell
+```
+
+
+シーシェル 色
+
+### Sienna {#Sienna}
+```
+public static final DrawingColor Sienna
+```
+
+
+シエナ 色
+
+### Silver {#Silver}
+```
+public static final DrawingColor Silver
+```
+
+
+シルバー 色
+
+### SkyBlue {#SkyBlue}
+```
+public static final DrawingColor SkyBlue
+```
+
+
+スカイブルー 色
+
+### SlateBlue {#SlateBlue}
+```
+public static final DrawingColor SlateBlue
+```
+
+
+スレートブルー 色
+
+### SlateGray {#SlateGray}
+```
+public static final DrawingColor SlateGray
+```
+
+
+スレートグレー 色
+
+### Snow {#Snow}
+```
+public static final DrawingColor Snow
+```
+
+
+スノー色
+
+### SpringGreen {#SpringGreen}
+```
+public static final DrawingColor SpringGreen
+```
+
+
+スプリンググリーン色
+
+### SteelBlue {#SteelBlue}
+```
+public static final DrawingColor SteelBlue
+```
+
+
+スチールブルー色
+
+### Tan {#Tan}
+```
+public static final DrawingColor Tan
+```
+
+
+タン色タイプ
+
+### Teal {#Teal}
+```
+public static final DrawingColor Teal
+```
+
+
+ティール色
+
+### Thistle {#Thistle}
+```
+public static final DrawingColor Thistle
+```
+
+
+シスル色
+
+### Tomato {#Tomato}
+```
+public static final DrawingColor Tomato
+```
+
+
+トマト色
+
+### Turquoise {#Turquoise}
+```
+public static final DrawingColor Turquoise
+```
+
+
+ターコイズ色
+
+### Violet {#Violet}
+```
+public static final DrawingColor Violet
+```
+
+
+バイオレット色
+
+### Wheat {#Wheat}
+```
+public static final DrawingColor Wheat
+```
+
+
+ウィート色
+
+### White {#White}
+```
+public static final DrawingColor White
+```
+
+
+白色
+
+### WhiteSmoke {#WhiteSmoke}
+```
+public static final DrawingColor WhiteSmoke
+```
+
+
+ホワイトスモーク色
+
+### Yellow {#Yellow}
+```
+public static final DrawingColor Yellow
+```
+
+
+黄色
+
+### YellowGreen {#YellowGreen}
+```
+public static final DrawingColor YellowGreen
+```
+
+
+黄緑色
+
+### undefined {#undefined}
+```
+public static final DrawingColor undefined
+```
+
+
+未定義の色です。デフォルト値が使用されます。
+
+### <T>valueOf(Class<T> arg0, String arg1) {#-T-valueOf-java.lang.Class-T--java.lang.String}
+```
+public static T <T>valueOf(Class<T> arg0, String arg1)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | java.lang.Class<T> |  |
+| arg1 | java.lang.String |  |
+
+**Returns:**
+T
+### ToSystem(DrawingColor color) {#ToSystem-com.aspose.omr.DrawingColor}
+```
+public static System.Drawing.Color ToSystem(DrawingColor color)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| color | [DrawingColor](../../com.aspose.omr/drawingcolor/) |  |
+
+**Returns:**
+com.aspose.ms.System.Drawing.Color
+### compareTo(E arg0) {#compareTo-E}
+```
+public final int compareTo(E arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | E |  |
+
+**Returns:**
+int
+### equals(Object arg0) {#equals-java.lang.Object}
+```
+public final boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getDeclaringClass() {#getDeclaringClass}
+```
+public final Class<E> getDeclaringClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<E>
+### hashCode() {#hashCode}
+```
+public final int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### name() {#name}
+```
+public final String name()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### notify() {#notify}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### ordinal() {#ordinal}
+```
+public final int ordinal()
+```
+
+
+
+
+**Returns:**
+int
+### toString() {#toString}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### valueOf(String name) {#valueOf-java.lang.String}
+```
+public static DrawingColor valueOf(String name)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 名前 | java.lang.String |  |
+
+**Returns:**
+[DrawingColor](../../com.aspose.omr/drawingcolor/)
+### values() {#values}
+```
+public static DrawingColor[] values()
+```
+
+
+
+
+**Returns:**
+com.aspose.omr.DrawingColor[]
+### wait() {#wait}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/japanese/java/com.aspose.omr/finalizationdata/_index.md
+++ b/japanese/java/com.aspose.omr/finalizationdata/_index.md
@@ -1,0 +1,211 @@
+---
+title: "FinalizationData"
+second_title: "Aspose.OMR for Java API リファレンス"
+description: "最終化データを表します"
+type: docs
+weight: 13
+url: /ja/java/com.aspose.omr/finalizationdata/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public class FinalizationData
+```
+
+最終化データを表します
+## コンストラクタ
+
+| コンストラクタ | 説明 |
+| --- | --- |
+| [FinalizationData()](#FinalizationData) |  |
+## メソッド
+
+| メソッド | 説明 |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object) |  |
+| [getAnswerText()](#getAnswerText) | テンプレート画像の認識結果を取得または設定します |
+| [getAnswers()](#getAnswers) |  |
+| [getClass()](#getClass) |  |
+| [getWarnings()](#getWarnings) | OMR Coreから受信した警告を取得または設定します |
+| [hashCode()](#hashCode) |  |
+| [notify()](#notify) |  |
+| [notifyAll()](#notifyAll) |  |
+| [setAnswerText(String[] value)](#setAnswerText-java.lang.String) | テンプレート画像の認識結果を取得または設定します |
+| [setAnswers(String value)](#setAnswers-java.lang.String) |  |
+| [setWarnings(String[] value)](#setWarnings-java.lang.String) | OMR Coreから受信した警告を取得または設定します |
+| [toString()](#toString) |  |
+| [wait()](#wait) |  |
+| [wait(long arg0)](#wait-long) |  |
+| [wait(long arg0, int arg1)](#wait-long-int) |  |
+### FinalizationData() {#FinalizationData}
+```
+public FinalizationData()
+```
+
+
+### equals(Object arg0) {#equals-java.lang.Object}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getAnswerText() {#getAnswerText}
+```
+public final String[] getAnswerText()
+```
+
+
+テンプレート画像の認識結果を取得または設定します
+
+**Returns:**
+java.lang.String[] - テンプレート画像の認識結果
+### getAnswers() {#getAnswers}
+```
+public final String getAnswers()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### getClass() {#getClass}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getWarnings() {#getWarnings}
+```
+public final String[] getWarnings()
+```
+
+
+OMR Coreから受信した警告を取得または設定します
+
+**Returns:**
+java.lang.String[] - OMR Coreから受信した警告
+### hashCode() {#hashCode}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setAnswerText(String[] value) {#setAnswerText-java.lang.String}
+```
+public final void setAnswerText(String[] value)
+```
+
+
+テンプレート画像の認識結果を取得または設定します
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | java.lang.String[] | テンプレート画像の認識結果 |
+
+### setAnswers(String value) {#setAnswers-java.lang.String}
+```
+public final void setAnswers(String value)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | java.lang.String |  |
+
+### setWarnings(String[] value) {#setWarnings-java.lang.String}
+```
+public final void setWarnings(String[] value)
+```
+
+
+OMR Coreから受信した警告を取得または設定します
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | java.lang.String[] | OMR Coreから受信した警告 |
+
+### toString() {#toString}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/japanese/java/com.aspose.omr/fontstyle/_index.md
+++ b/japanese/java/com.aspose.omr/fontstyle/_index.md
@@ -1,0 +1,262 @@
+---
+title: "FontStyle"
+second_title: "Aspose.OMR for Java API リファレンス"
+description: 
+type: docs
+weight: 36
+url: /ja/java/com.aspose.omr/fontstyle/
+---
+
+**Inheritance:**
+java.lang.Object, java.lang.Enum
+```
+public enum FontStyle extends Enum<FontStyle>
+```
+## フィールド
+
+| フィールド | 説明 |
+| --- | --- |
+| [Bold](#Bold) |  |
+| [Italic](#Italic) |  |
+| [Regular](#Regular) |  |
+| [Strikeout](#Strikeout) |  |
+| [Underline](#Underline) |  |
+| [undefined](#undefined) |  |
+## メソッド
+
+| メソッド | 説明 |
+| --- | --- |
+| [<T>valueOf(Class<T> arg0, String arg1)](#-T-valueOf-java.lang.Class-T--java.lang.String) |  |
+| [compareTo(E arg0)](#compareTo-E) |  |
+| [equals(Object arg0)](#equals-java.lang.Object) |  |
+| [getClass()](#getClass) |  |
+| [getDeclaringClass()](#getDeclaringClass) |  |
+| [hashCode()](#hashCode) |  |
+| [name()](#name) |  |
+| [notify()](#notify) |  |
+| [notifyAll()](#notifyAll) |  |
+| [ordinal()](#ordinal) |  |
+| [toString()](#toString) |  |
+| [valueOf(String name)](#valueOf-java.lang.String) |  |
+| [values()](#values) |  |
+| [wait()](#wait) |  |
+| [wait(long arg0)](#wait-long) |  |
+| [wait(long arg0, int arg1)](#wait-long-int) |  |
+### Bold {#Bold}
+```
+public static final FontStyle Bold
+```
+
+
+### Italic {#Italic}
+```
+public static final FontStyle Italic
+```
+
+
+### Regular {#Regular}
+```
+public static final FontStyle Regular
+```
+
+
+### Strikeout {#Strikeout}
+```
+public static final FontStyle Strikeout
+```
+
+
+### Underline {#Underline}
+```
+public static final FontStyle Underline
+```
+
+
+### undefined {#undefined}
+```
+public static final FontStyle undefined
+```
+
+
+### <T>valueOf(Class<T> arg0, String arg1) {#-T-valueOf-java.lang.Class-T--java.lang.String}
+```
+public static T <T>valueOf(Class<T> arg0, String arg1)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | java.lang.Class<T> |  |
+| arg1 | java.lang.String |  |
+
+**Returns:**
+T
+### compareTo(E arg0) {#compareTo-E}
+```
+public final int compareTo(E arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | E |  |
+
+**Returns:**
+int
+### equals(Object arg0) {#equals-java.lang.Object}
+```
+public final boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getDeclaringClass() {#getDeclaringClass}
+```
+public final Class<E> getDeclaringClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<E>
+### hashCode() {#hashCode}
+```
+public final int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### name() {#name}
+```
+public final String name()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### notify() {#notify}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### ordinal() {#ordinal}
+```
+public final int ordinal()
+```
+
+
+
+
+**Returns:**
+int
+### toString() {#toString}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### valueOf(String name) {#valueOf-java.lang.String}
+```
+public static FontStyle valueOf(String name)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 名前 | java.lang.String |  |
+
+**Returns:**
+[FontStyle](../../com.aspose.omr/fontstyle/)
+### values() {#values}
+```
+public static FontStyle[] values()
+```
+
+
+
+
+**Returns:**
+com.aspose.omr.FontStyle[]
+### wait() {#wait}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/japanese/java/com.aspose.omr/generationresult/_index.md
+++ b/japanese/java/com.aspose.omr/generationresult/_index.md
@@ -1,0 +1,265 @@
+---
+title: "GenerationResult"
+second_title: "Aspose.OMR for Java API リファレンス"
+description: "テンプレート生成の結果"
+type: docs
+weight: 14
+url: /ja/java/com.aspose.omr/generationresult/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public class GenerationResult
+```
+
+テンプレート生成の結果です。テンプレート画像とテンプレート（画像上の要素位置を記述した json）を含みます。
+## メソッド
+
+| メソッド | 説明 |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object) |  |
+| [getClass()](#getClass) |  |
+| [getErrorCode()](#getErrorCode) | エラーコードを取得または設定します。 |
+| [getErrorMessage()](#getErrorMessage) | エラーを説明するメッセージを取得または設定します。 |
+| [getTemplate()](#getTemplate) | テンプレート JSON 文字列を取得します |
+| [getTemplateImage()](#getTemplateImage) | 生成されたテンプレート画像を取得または設定します |
+| [getWarnings()](#getWarnings) | 生成中に発生した非致命的な障害を説明する警告メッセージのリストを取得または設定します |
+| [hashCode()](#hashCode) |  |
+| [notify()](#notify) |  |
+| [notifyAll()](#notifyAll) |  |
+| [save(String folder, String name)](#save-java.lang.String-java.lang.String) | テンプレート画像とテンプレートを指定されたフォルダーに保存します |
+| [setErrorCode(int value)](#setErrorCode-int) | エラーコードを取得または設定します。 |
+| [setErrorMessage(String value)](#setErrorMessage-java.lang.String) | エラーを説明するメッセージを取得または設定します。 |
+| [setTemplate(String value)](#setTemplate-java.lang.String) | テンプレート JSON 文字列を設定します |
+| [setTemplateImage(BufferedImage value)](#setTemplateImage-java.awt.image.BufferedImage) | 生成されたテンプレート画像を取得または設定します |
+| [setWarnings(List<String> value)](#setWarnings-java.util.List-java.lang.String) | 生成中に発生した非致命的な障害を説明する警告メッセージのリストを取得または設定します |
+| [toString()](#toString) |  |
+| [wait()](#wait) |  |
+| [wait(long arg0)](#wait-long) |  |
+| [wait(long arg0, int arg1)](#wait-long-int) |  |
+### equals(Object arg0) {#equals-java.lang.Object}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getErrorCode() {#getErrorCode}
+```
+public final int getErrorCode()
+```
+
+
+エラーコードを取得または設定します。エラーが発生しなければ 0 です。
+
+**Returns:**
+int - エラーコード
+### getErrorMessage() {#getErrorMessage}
+```
+public final String getErrorMessage()
+```
+
+
+エラーを説明するメッセージを取得または設定します。エラーが発生しなければ空です。
+
+**Returns:**
+java.lang.String - エラーを説明するメッセージ
+### getTemplate() {#getTemplate}
+```
+public final String getTemplate()
+```
+
+
+テンプレート JSON 文字列を取得します
+
+**Returns:**
+java.lang.String - テンプレート JSON 文字列
+### getTemplateImage() {#getTemplateImage}
+```
+public final BufferedImage getTemplateImage()
+```
+
+
+生成されたテンプレート画像を取得または設定します
+
+**Returns:**
+java.awt.image.BufferedImage
+### getWarnings() {#getWarnings}
+```
+public final List<String> getWarnings()
+```
+
+
+生成中に発生した非致命的な障害を説明する警告メッセージのリストを取得または設定します
+
+**Returns:**
+java.util.List<java.lang.String>
+### hashCode() {#hashCode}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### save(String folder, String name) {#save-java.lang.String-java.lang.String}
+```
+public final void save(String folder, String name)
+```
+
+
+テンプレート画像とテンプレートを指定されたフォルダーに保存します
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| フォルダー | java.lang.String | 保存先フォルダー |
+| 名前 | java.lang.String | テンプレートの名前 |
+
+### setErrorCode(int value) {#setErrorCode-int}
+```
+public final void setErrorCode(int value)
+```
+
+
+エラーコードを取得または設定します。エラーが発生しなければ 0 です。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | int | エラーコード |
+
+### setErrorMessage(String value) {#setErrorMessage-java.lang.String}
+```
+public final void setErrorMessage(String value)
+```
+
+
+エラーを説明するメッセージを取得または設定します。エラーが発生しなければ空です。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | java.lang.String | エラーを説明するメッセージ |
+
+### setTemplate(String value) {#setTemplate-java.lang.String}
+```
+public final void setTemplate(String value)
+```
+
+
+テンプレート JSON 文字列を設定します
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | java.lang.String | テンプレート JSON 文字列 |
+
+### setTemplateImage(BufferedImage value) {#setTemplateImage-java.awt.image.BufferedImage}
+```
+public final void setTemplateImage(BufferedImage value)
+```
+
+
+生成されたテンプレート画像を取得または設定します
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | java.awt.image.BufferedImage |  |
+
+### setWarnings(List<String> value) {#setWarnings-java.util.List-java.lang.String}
+```
+public final void setWarnings(List<String> value)
+```
+
+
+生成中に発生した非致命的な障害を説明する警告メッセージのリストを取得または設定します
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | java.util.List<java.lang.String> |  |
+
+### toString() {#toString}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/japanese/java/com.aspose.omr/globalpagesettings/_index.md
+++ b/japanese/java/com.aspose.omr/globalpagesettings/_index.md
@@ -1,0 +1,210 @@
+---
+title: "GlobalPageSettings"
+second_title: "Aspose.OMR for Java API リファレンス"
+description: "すべてのページ要素に適用されるグローバル設定"
+type: docs
+weight: 15
+url: /ja/java/com.aspose.omr/globalpagesettings/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public class GlobalPageSettings
+```
+
+すべてのページ要素に適用されるグローバル設定です。
+## コンストラクタ
+
+| コンストラクタ | 説明 |
+| --- | --- |
+| [GlobalPageSettings()](#GlobalPageSettings) |  |
+## フィールド
+
+| フィールド | 説明 |
+| --- | --- |
+| [BubbleColor](#BubbleColor) | ページ上の各バブルの色 |
+| [BubbleSize](#BubbleSize) |  |
+| [FontColor](#FontColor) | すべてのテキストシンボルの色。テキスト要素自体で色を指定することで上書きできます。 |
+| [FontFamily](#FontFamily) | フォントのファミリー |
+| [FontSize](#FontSize) | フォントのサイズ |
+| [FontStyle](#FontStyle) | フォントのスタイル |
+| [PaperSize](#PaperSize) | ページサイズ。 |
+| [ReferencePoints](#ReferencePoints) | テンプレートのリファレンスポイントの動作を記述する設定：角に黒い四角、間に回転マーカーとして黒い長方形。 |
+## メソッド
+
+| メソッド | 説明 |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object) |  |
+| [getClass()](#getClass) |  |
+| [hashCode()](#hashCode) |  |
+| [notify()](#notify) |  |
+| [notifyAll()](#notifyAll) |  |
+| [toString()](#toString) |  |
+| [wait()](#wait) |  |
+| [wait(long arg0)](#wait-long) |  |
+| [wait(long arg0, int arg1)](#wait-long-int) |  |
+### GlobalPageSettings() {#GlobalPageSettings}
+```
+public GlobalPageSettings()
+```
+
+
+### BubbleColor {#BubbleColor}
+```
+public DrawingColor BubbleColor
+```
+
+
+ページ上の各バブルの色
+
+### BubbleSize {#BubbleSize}
+```
+public BubbleSize BubbleSize
+```
+
+
+### FontColor {#FontColor}
+```
+public DrawingColor FontColor
+```
+
+
+すべてのテキストシンボルの色。テキスト要素自体で色を指定することで上書きできます。
+
+### FontFamily {#FontFamily}
+```
+public String FontFamily
+```
+
+
+フォントのファミリー
+
+### FontSize {#FontSize}
+```
+public int FontSize
+```
+
+
+フォントのサイズ
+
+### FontStyle {#FontStyle}
+```
+public FontStyle FontStyle
+```
+
+
+フォントのスタイル
+
+### PaperSize {#PaperSize}
+```
+public PaperSize PaperSize
+```
+
+
+ページサイズ。300 dpi の用紙比率を使用します。
+
+### ReferencePoints {#ReferencePoints}
+```
+public ReferencePointsSettings ReferencePoints
+```
+
+
+テンプレートのリファレンスポイントの動作を記述する設定：角に黒い四角、間に回転マーカーとして黒い長方形。 \\*
+
+### equals(Object arg0) {#equals-java.lang.Object}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### hashCode() {#hashCode}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/japanese/java/com.aspose.omr/gridelement/_index.md
+++ b/japanese/java/com.aspose.omr/gridelement/_index.md
@@ -1,0 +1,426 @@
+---
+title: "GridElement"
+second_title: "Aspose.OMR for Java API リファレンス"
+description: 
+type: docs
+weight: 16
+url: /ja/java/com.aspose.omr/gridelement/
+---
+
+**Inheritance:**
+java.lang.Object, [com.aspose.omr.OmrElement](../../com.aspose.omr/omrelement/)
+```
+public class GridElement extends OmrElement
+```
+## コンストラクタ
+
+| コンストラクタ | 説明 |
+| --- | --- |
+| [GridElement()](#GridElement) |  |
+## フィールド
+
+| フィールド | 説明 |
+| --- | --- |
+| [ElementType](#ElementType) |  |
+## メソッド
+
+| メソッド | 説明 |
+| --- | --- |
+| [addChoiceBox(ChoiceBoxElement choiceBox)](#addChoiceBox-com.aspose.omr.ChoiceBoxElement) |  |
+| [addChoiceBox(String name, int width, int height, int top, int left)](#addChoiceBox-java.lang.String-int-int-int-int) |  |
+| [equals(Object arg0)](#equals-java.lang.Object) |  |
+| [getChoiceBoxes()](#getChoiceBoxes) |  |
+| [getClass()](#getClass) |  |
+| [getHeight()](#getHeight) | 質問の高さを取得または設定します |
+| [getLeft()](#getLeft) | 質問の左位置を取得または設定します |
+| [getName()](#getName) | 質問名を取得します |
+| [getOrientation()](#getOrientation) |  |
+| [getOrientationString()](#getOrientationString) |  |
+| [getRect()](#getRect) |  |
+| [getTop()](#getTop) | 質問の上位置を取得または設定します |
+| [getWidth()](#getWidth) | 質問の幅を取得または設定します |
+| [hashCode()](#hashCode) |  |
+| [isAlignedHorizontal()](#isAlignedHorizontal) | バブルが水平に配置されているかどうかを示す値を取得または設定します |
+| [isAlignedVertical()](#isAlignedVertical) | バブルが垂直に配置されているかどうかを示す値を取得または設定します |
+| [notify()](#notify) |  |
+| [notifyAll()](#notifyAll) |  |
+| [setAlignedHorizontal(boolean value)](#setAlignedHorizontal-boolean) | バブルが水平に配置されているかどうかを示す値を取得または設定します |
+| [setAlignedVertical(boolean value)](#setAlignedVertical-boolean) | バブルが垂直に配置されているかどうかを示す値を取得または設定します |
+| [setChoiceBoxes(System.Collections.Generic.List<OmrElement> value)](#setChoiceBoxes-com.aspose.ms.System.Collections.Generic.List-com.aspose.omr.OmrElement) |  |
+| [setHeight(double value)](#setHeight-double) | 質問の高さを取得または設定します |
+| [setLeft(double value)](#setLeft-double) | 質問の左位置を取得または設定します |
+| [setName(String value)](#setName-java.lang.String) | 質問名を設定します |
+| [setOrientation(int value)](#setOrientation-int) |  |
+| [setTop(double value)](#setTop-double) | 質問の上位置を取得または設定します |
+| [setWidth(double value)](#setWidth-double) | 質問の幅を取得または設定します |
+| [toString()](#toString) |  |
+| [wait()](#wait) |  |
+| [wait(long arg0)](#wait-long) |  |
+| [wait(long arg0, int arg1)](#wait-long-int) |  |
+### GridElement() {#GridElement}
+```
+public GridElement()
+```
+
+
+### ElementType {#ElementType}
+```
+public String ElementType
+```
+
+
+### addChoiceBox(ChoiceBoxElement choiceBox) {#addChoiceBox-com.aspose.omr.ChoiceBoxElement}
+```
+public final void addChoiceBox(ChoiceBoxElement choiceBox)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| choiceBox | [ChoiceBoxElement](../../com.aspose.omr/choiceboxelement/) |  |
+
+### addChoiceBox(String name, int width, int height, int top, int left) {#addChoiceBox-java.lang.String-int-int-int-int}
+```
+public final ChoiceBoxElement addChoiceBox(String name, int width, int height, int top, int left)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 名前 | java.lang.String |  |
+| 幅 | int |  |
+| 高さ | int |  |
+| 上 | int |  |
+| 左 | int |  |
+
+**Returns:**
+[ChoiceBoxElement](../../com.aspose.omr/choiceboxelement/)
+### equals(Object arg0) {#equals-java.lang.Object}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getChoiceBoxes() {#getChoiceBoxes}
+```
+public final System.Collections.Generic.List<OmrElement> getChoiceBoxes()
+```
+
+
+
+
+**Returns:**
+com.aspose.ms.System.Collections.Generic.List<com.aspose.omr.OmrElement>
+### getClass() {#getClass}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getHeight() {#getHeight}
+```
+public final double getHeight()
+```
+
+
+質問の高さを取得または設定します
+
+**Returns:**
+double - 高さ
+### getLeft() {#getLeft}
+```
+public final double getLeft()
+```
+
+
+質問の左位置を取得または設定します
+
+**Returns:**
+double - 左
+### getName() {#getName}
+```
+public final String getName()
+```
+
+
+質問名を取得します
+
+**Returns:**
+java.lang.String - 質問名
+### getOrientation() {#getOrientation}
+```
+public final int getOrientation()
+```
+
+
+
+
+**Returns:**
+int
+### getOrientationString() {#getOrientationString}
+```
+public final String getOrientationString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### getRect() {#getRect}
+```
+public System.Drawing.RectangleF getRect()
+```
+
+
+
+
+**Returns:**
+com.aspose.ms.System.Drawing.RectangleF
+### getTop() {#getTop}
+```
+public final double getTop()
+```
+
+
+質問の上位置を取得または設定します
+
+**Returns:**
+double - 上
+### getWidth() {#getWidth}
+```
+public final double getWidth()
+```
+
+
+質問の幅を取得または設定します
+
+**Returns:**
+double - 幅
+### hashCode() {#hashCode}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### isAlignedHorizontal() {#isAlignedHorizontal}
+```
+public final boolean isAlignedHorizontal()
+```
+
+
+バブルが水平に配置されているかどうかを示す値を取得または設定します
+
+**Returns:**
+boolean - バブルが水平に配置されているかどうかを示す値
+### isAlignedVertical() {#isAlignedVertical}
+```
+public final boolean isAlignedVertical()
+```
+
+
+バブルが垂直に配置されているかどうかを示す値を取得または設定します
+
+**Returns:**
+boolean - バブルが垂直に配置されているかどうかを示す値
+### notify() {#notify}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setAlignedHorizontal(boolean value) {#setAlignedHorizontal-boolean}
+```
+public final void setAlignedHorizontal(boolean value)
+```
+
+
+バブルが水平に配置されているかどうかを示す値を取得または設定します
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | boolean | バブルが水平に配置されているかどうかを示す値 |
+
+### setAlignedVertical(boolean value) {#setAlignedVertical-boolean}
+```
+public final void setAlignedVertical(boolean value)
+```
+
+
+バブルが垂直に配置されているかどうかを示す値を取得または設定します
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | boolean | バブルが垂直に配置されているかどうかを示す値 |
+
+### setChoiceBoxes(System.Collections.Generic.List<OmrElement> value) {#setChoiceBoxes-com.aspose.ms.System.Collections.Generic.List-com.aspose.omr.OmrElement}
+```
+public final void setChoiceBoxes(System.Collections.Generic.List<OmrElement> value)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | com.aspose.ms.System.Collections.Generic.List<com.aspose.omr.OmrElement> |  |
+
+### setHeight(double value) {#setHeight-double}
+```
+public final void setHeight(double value)
+```
+
+
+質問の高さを取得または設定します
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | double | 高さ |
+
+### setLeft(double value) {#setLeft-double}
+```
+public final void setLeft(double value)
+```
+
+
+質問の左位置を取得または設定します
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | double | 左 |
+
+### setName(String value) {#setName-java.lang.String}
+```
+public final void setName(String value)
+```
+
+
+質問名を設定します
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | java.lang.String | 質問名 |
+
+### setOrientation(int value) {#setOrientation-int}
+```
+public final void setOrientation(int value)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | int |  |
+
+### setTop(double value) {#setTop-double}
+```
+public final void setTop(double value)
+```
+
+
+質問の上位置を取得または設定します
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | double | 上 |
+
+### setWidth(double value) {#setWidth-double}
+```
+public final void setWidth(double value)
+```
+
+
+質問の幅を取得または設定します
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | double | 幅 |
+
+### toString() {#toString}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/japanese/java/com.aspose.omr/imagecollection/_index.md
+++ b/japanese/java/com.aspose.omr/imagecollection/_index.md
@@ -1,0 +1,153 @@
+---
+title: "ImageCollection"
+second_title: "Aspose.OMR for Java API リファレンス"
+description: "テンプレート生成に使用できる画像のコレクション"
+type: docs
+weight: 17
+url: /ja/java/com.aspose.omr/imagecollection/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public class ImageCollection
+```
+
+テンプレート生成に使用できる画像のコレクションです。
+## コンストラクタ
+
+| コンストラクタ | 説明 |
+| --- | --- |
+| [ImageCollection()](#ImageCollection) | コレクションのインスタンスを作成するデフォルトコンストラクタ |
+## メソッド
+
+| メソッド | 説明 |
+| --- | --- |
+| [add(String imageName, InputStream stream)](#add-java.lang.String-java.io.InputStream) | このコレクションに画像を挿入します。 |
+| [equals(Object arg0)](#equals-java.lang.Object) |  |
+| [getClass()](#getClass) |  |
+| [hashCode()](#hashCode) |  |
+| [notify()](#notify) |  |
+| [notifyAll()](#notifyAll) |  |
+| [toString()](#toString) |  |
+| [wait()](#wait) |  |
+| [wait(long arg0)](#wait-long) |  |
+| [wait(long arg0, int arg1)](#wait-long-int) |  |
+### ImageCollection() {#ImageCollection}
+```
+public ImageCollection()
+```
+
+
+コレクションのインスタンスを作成するデフォルトコンストラクタ
+
+### add(String imageName, InputStream stream) {#add-java.lang.String-java.io.InputStream}
+```
+public void add(String imageName, InputStream stream)
+```
+
+
+このコレクションに画像を挿入します。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| imageName | java.lang.String | ?image 要素と等しくなる必要があります 例: ?image=logo.png collection.Add(\"logo.png\",stream) |
+| ストリーム | java.io.InputStream |  |
+
+### equals(Object arg0) {#equals-java.lang.Object}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### hashCode() {#hashCode}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/japanese/java/com.aspose.omr/iomrelement/_index.md
+++ b/japanese/java/com.aspose.omr/iomrelement/_index.md
@@ -1,0 +1,64 @@
+---
+title: "IOmrElement"
+second_title: "Aspose.OMR for Java API リファレンス"
+description: "OMR要素のインターフェイス"
+type: docs
+weight: 31
+url: /ja/java/com.aspose.omr/iomrelement/
+---
+```
+public interface IOmrElement
+```
+
+OMR要素のインターフェイス
+## メソッド
+
+| メソッド | 説明 |
+| --- | --- |
+| [getAnswer()](#getAnswer) | 認識結果の文字列を作成します |
+| [getCsv()](#getCsv) | 回答をカンマ区切りの文字列として作成します |
+| [getQuestionName()](#getQuestionName) | 質問名を取得します |
+| [setQuestionName(String value)](#setQuestionName-java.lang.String) | 質問名を設定します |
+### getAnswer() {#getAnswer}
+```
+public abstract String getAnswer()
+```
+
+
+認識結果の文字列を作成します
+
+**Returns:**
+java.lang.String - 認識結果を含む文字列
+### getCsv() {#getCsv}
+```
+public abstract String getCsv()
+```
+
+
+回答をカンマ区切りの文字列として作成します
+
+**Returns:**
+java.lang.String - 認識結果をCSV文字列として表したもの
+### getQuestionName() {#getQuestionName}
+```
+public abstract String getQuestionName()
+```
+
+
+質問名を取得します
+
+**Returns:**
+java.lang.String - 質問名
+### setQuestionName(String value) {#setQuestionName-java.lang.String}
+```
+public abstract void setQuestionName(String value)
+```
+
+
+質問名を設定します
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | java.lang.String | 質問名 |
+

--- a/japanese/java/com.aspose.omr/license/_index.md
+++ b/japanese/java/com.aspose.omr/license/_index.md
@@ -1,0 +1,194 @@
+---
+title: "ライセンス"
+second_title: "Aspose.OMR for Java API リファレンス"
+description: "コンポーネントにライセンスを付与するためのメソッドを提供します"
+type: docs
+weight: 18
+url: /ja/java/com.aspose.omr/license/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public class License
+```
+
+コンポーネントをライセンスするためのメソッドを提供します。
+
+この例では、コンポーネントが含まれるフォルダー、呼び出しアセンブリが含まれるフォルダー、エントリアセンブリのフォルダー、そして呼び出しアセンブリの埋め込みリソース内で、MyLicense.lic という名前のライセンスファイルを検索しようとします。
+
+License license = new License();
+license.setLicense("MyLicense.lic");
+## コンストラクタ
+
+| コンストラクタ | 説明 |
+| --- | --- |
+| [License()](#License) | このクラスの新しいインスタンスを初期化します。 |
+## メソッド
+
+| メソッド | 説明 |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object) |  |
+| [getClass()](#getClass) |  |
+| [hashCode()](#hashCode) |  |
+| [notify()](#notify) |  |
+| [notifyAll()](#notifyAll) |  |
+| [setLicense(InputStream stream)](#setLicense-java.io.InputStream) | コンポーネントにライセンスを付与します。 |
+| [setLicense(String licenseName)](#setLicense-java.lang.String) | コンポーネントにライセンスを付与します。 |
+| [toString()](#toString) |  |
+| [wait()](#wait) |  |
+| [wait(long arg0)](#wait-long) |  |
+| [wait(long arg0, int arg1)](#wait-long-int) |  |
+### License() {#License}
+```
+public License()
+```
+
+
+このクラスの新しいインスタンスを初期化します。
+
+この例では、コンポーネントが含まれるフォルダー、呼び出しアセンブリが含まれるフォルダー、エントリアセンブリのフォルダー、そして呼び出しアセンブリの埋め込みリソース内で、MyLicense.lic という名前のライセンスファイルを検索しようとします。
+
+License license = new License();
+license.setLicense("MyLicense.lic");
+
+### equals(Object arg0) {#equals-java.lang.Object}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### hashCode() {#hashCode}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setLicense(InputStream stream) {#setLicense-java.io.InputStream}
+```
+public void setLicense(InputStream stream)
+```
+
+
+コンポーネントにライセンスを付与します。
+
+ライセンスを含むストリーム。
+
+このメソッドを使用して、ストリームからライセンスをロードします。
+
+License license = new License();
+license.setLicense(myStream);
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| ストリーム | java.io.InputStream | license ストリーム |
+
+### setLicense(String licenseName) {#setLicense-java.lang.String}
+```
+public void setLicense(String licenseName)
+```
+
+
+コンポーネントにライセンスを付与します。
+
+次の場所でライセンスを検索しようとします：
+
+1. 明示的なパス。
+
+2. コンポーネント jar ファイルのフォルダー。
+
+この例では、コンポーネントが含まれるフォルダー、呼び出しアセンブリが含まれるフォルダー、エントリアセンブリのフォルダー、そして呼び出しアセンブリの埋め込みリソース内で、MyLicense.lic という名前のライセンスファイルを検索しようとします。
+
+License license = new License();
+license.setLicense("MyLicense.lic");
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| licenseName | java.lang.String | 完全なファイル名または短いファイル名、あるいは埋め込みリソースの名前を指定できます。空文字列を使用すると評価モードに切り替わります。 |
+
+### toString() {#toString}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/japanese/java/com.aspose.omr/metered/_index.md
+++ b/japanese/java/com.aspose.omr/metered/_index.md
@@ -1,0 +1,186 @@
+---
+title: "従量制"
+second_title: "Aspose.OMR for Java API リファレンス"
+description: "従量制キーを設定するメソッドを提供します"
+type: docs
+weight: 19
+url: /ja/java/com.aspose.omr/metered/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public class Metered
+```
+
+メーターキーを設定するためのメソッドを提供します。
+
+--------------------
+
+この例では、従量制の公開キーと秘密キーを設定しようとします
+
+```
+The component jar file:
+  
+ 	Metered matered = new Metered();
+ 	matered.setMeteredKey("PublicKey", "PrivateKey");
+```
+## コンストラクタ
+
+| コンストラクタ | 説明 |
+| --- | --- |
+| [Metered()](#Metered) | このクラスの新しいインスタンスを初期化します。 |
+## メソッド
+
+| メソッド | 説明 |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object) |  |
+| [getClass()](#getClass) |  |
+| [getConsumptionCredit()](#getConsumptionCredit) | 消費クレジットを取得します |
+| [getConsumptionQuantity()](#getConsumptionQuantity) | 消費ファイルサイズを取得します |
+| [hashCode()](#hashCode) |  |
+| [notify()](#notify) |  |
+| [notifyAll()](#notifyAll) |  |
+| [setMeteredKey(String publicKey, String privateKey)](#setMeteredKey-java.lang.String-java.lang.String) | 従量制の公開キーと秘密キーを設定します |
+| [toString()](#toString) |  |
+| [wait()](#wait) |  |
+| [wait(long arg0)](#wait-long) |  |
+| [wait(long arg0, int arg1)](#wait-long-int) |  |
+### Metered() {#Metered}
+```
+public Metered()
+```
+
+
+このクラスの新しいインスタンスを初期化します。
+
+### equals(Object arg0) {#equals-java.lang.Object}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getConsumptionCredit() {#getConsumptionCredit}
+```
+public static BigDecimal getConsumptionCredit()
+```
+
+
+消費クレジットを取得します
+
+**Returns:**
+java.math.BigDecimal - 消費量
+### getConsumptionQuantity() {#getConsumptionQuantity}
+```
+public static BigDecimal getConsumptionQuantity()
+```
+
+
+消費ファイルサイズを取得します
+
+**Returns:**
+java.math.BigDecimal - 消費量
+### hashCode() {#hashCode}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setMeteredKey(String publicKey, String privateKey) {#setMeteredKey-java.lang.String-java.lang.String}
+```
+public void setMeteredKey(String publicKey, String privateKey)
+```
+
+
+従量制の公開キーと秘密キーを設定します
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| publicKey | java.lang.String | 公開キー |
+| privateKey | java.lang.String | 秘密キー |
+
+### toString() {#toString}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/japanese/java/com.aspose.omr/omrbubble/_index.md
+++ b/japanese/java/com.aspose.omr/omrbubble/_index.md
@@ -1,0 +1,236 @@
+---
+title: "OmrBubble"
+second_title: "Aspose.OMR for Java API リファレンス"
+description: "単一の OMR バブルを表します"
+type: docs
+weight: 20
+url: /ja/java/com.aspose.omr/omrbubble/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public class OmrBubble
+```
+
+単一の OMR バブルを表します
+## コンストラクタ
+
+| コンストラクタ | 説明 |
+| --- | --- |
+| [OmrBubble()](#OmrBubble) |  |
+## メソッド
+
+| メソッド | 説明 |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object) |  |
+| [getClass()](#getClass) |  |
+| [getLeft()](#getLeft) | バブルの絶対左位置を取得します |
+| [getTop()](#getTop) | バブルの絶対上位置を取得します |
+| [getValue()](#getValue) | バブルの回答値を取得します（すなわち）。 |
+| [hashCode()](#hashCode) |  |
+| [isValid()](#isValid) | バブルが有効な位置にあるかどうかを示す値を取得します。 |
+| [notify()](#notify) |  |
+| [notifyAll()](#notifyAll) |  |
+| [setLeft(double value)](#setLeft-double) | バブルの絶対左位置を設定します |
+| [setTop(double value)](#setTop-double) | バブルの絶対上位置を設定します |
+| [setValid(boolean value)](#setValid-boolean) | バブルが有効な位置にあるかどうかを示す値を設定します。 |
+| [setValue(String value)](#setValue-java.lang.String) | バブルの回答値を設定します（すなわち）。 |
+| [toString()](#toString) |  |
+| [wait()](#wait) |  |
+| [wait(long arg0)](#wait-long) |  |
+| [wait(long arg0, int arg1)](#wait-long-int) |  |
+### OmrBubble() {#OmrBubble}
+```
+public OmrBubble()
+```
+
+
+### equals(Object arg0) {#equals-java.lang.Object}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getLeft() {#getLeft}
+```
+public final double getLeft()
+```
+
+
+バブルの絶対左位置を取得します
+
+**Returns:**
+double - バブルの絶対左位置
+### getTop() {#getTop}
+```
+public final double getTop()
+```
+
+
+バブルの絶対上位置を取得します
+
+**Returns:**
+double - バブルの絶対上位置
+### getValue() {#getValue}
+```
+public final String getValue()
+```
+
+
+バブルの回答値（マッピング値）を取得します
+
+**Returns:**
+java.lang.String - バブルの回答値
+### hashCode() {#hashCode}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### isValid() {#isValid}
+```
+public final boolean isValid()
+```
+
+
+バブルが有効な位置にあるかどうかを示す値を取得します。
+
+**Returns:**
+boolean - バブルが有効な位置にあるかを示す値
+### notify() {#notify}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setLeft(double value) {#setLeft-double}
+```
+public final void setLeft(double value)
+```
+
+
+バブルの絶対左位置を設定します
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | double | バブルの絶対左位置 |
+
+### setTop(double value) {#setTop-double}
+```
+public final void setTop(double value)
+```
+
+
+バブルの絶対上位置を設定します
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | double | バブルの絶対上位置 |
+
+### setValid(boolean value) {#setValid-boolean}
+```
+public final void setValid(boolean value)
+```
+
+
+バブルが有効な位置にあるかどうかを示す値を設定します。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | boolean | バブルが有効な位置にあるかを示す値 |
+
+### setValue(String value) {#setValue-java.lang.String}
+```
+public final void setValue(String value)
+```
+
+
+バブルの回答値（マッピング値）を設定します
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | java.lang.String | バブルの回答値 |
+
+### toString() {#toString}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/japanese/java/com.aspose.omr/omrelement/_index.md
+++ b/japanese/java/com.aspose.omr/omrelement/_index.md
@@ -1,0 +1,272 @@
+---
+title: "OmrElement"
+second_title: "Aspose.OMR for Java API リファレンス"
+description: "抽象クラスはベース OMR 質問を表し、すべての質問に共通のプロパティを含みます"
+type: docs
+weight: 21
+url: /ja/java/com.aspose.omr/omrelement/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public abstract class OmrElement
+```
+
+基本 OMR 質問を表す抽象クラスです。すべての質問に共通のプロパティを含みます。
+## コンストラクタ
+
+| コンストラクタ | 説明 |
+| --- | --- |
+| [OmrElement()](#OmrElement) |  |
+## メソッド
+
+| メソッド | 説明 |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object) |  |
+| [getClass()](#getClass) |  |
+| [getHeight()](#getHeight) | 質問の高さを取得または設定します |
+| [getLeft()](#getLeft) | 質問の左位置を取得または設定します |
+| [getName()](#getName) | 質問名を取得します |
+| [getRect()](#getRect) |  |
+| [getTop()](#getTop) | 質問の上位置を取得または設定します |
+| [getWidth()](#getWidth) | 質問の幅を取得または設定します |
+| [hashCode()](#hashCode) |  |
+| [notify()](#notify) |  |
+| [notifyAll()](#notifyAll) |  |
+| [setHeight(double value)](#setHeight-double) | 質問の高さを取得または設定します |
+| [setLeft(double value)](#setLeft-double) | 質問の左位置を取得または設定します |
+| [setName(String value)](#setName-java.lang.String) | 質問名を設定します |
+| [setTop(double value)](#setTop-double) | 質問の上位置を取得または設定します |
+| [setWidth(double value)](#setWidth-double) | 質問の幅を取得または設定します |
+| [toString()](#toString) |  |
+| [wait()](#wait) |  |
+| [wait(long arg0)](#wait-long) |  |
+| [wait(long arg0, int arg1)](#wait-long-int) |  |
+### OmrElement() {#OmrElement}
+```
+public OmrElement()
+```
+
+
+### equals(Object arg0) {#equals-java.lang.Object}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getHeight() {#getHeight}
+```
+public final double getHeight()
+```
+
+
+質問の高さを取得または設定します
+
+**Returns:**
+double - 高さ
+### getLeft() {#getLeft}
+```
+public final double getLeft()
+```
+
+
+質問の左位置を取得または設定します
+
+**Returns:**
+double - 左
+### getName() {#getName}
+```
+public final String getName()
+```
+
+
+質問名を取得します
+
+**Returns:**
+java.lang.String - 質問名
+### getRect() {#getRect}
+```
+public System.Drawing.RectangleF getRect()
+```
+
+
+
+
+**Returns:**
+com.aspose.ms.System.Drawing.RectangleF
+### getTop() {#getTop}
+```
+public final double getTop()
+```
+
+
+質問の上位置を取得または設定します
+
+**Returns:**
+double - 上
+### getWidth() {#getWidth}
+```
+public final double getWidth()
+```
+
+
+質問の幅を取得または設定します
+
+**Returns:**
+double - 幅
+### hashCode() {#hashCode}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setHeight(double value) {#setHeight-double}
+```
+public final void setHeight(double value)
+```
+
+
+質問の高さを取得または設定します
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | double | 高さ |
+
+### setLeft(double value) {#setLeft-double}
+```
+public final void setLeft(double value)
+```
+
+
+質問の左位置を取得または設定します
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | double | 左 |
+
+### setName(String value) {#setName-java.lang.String}
+```
+public final void setName(String value)
+```
+
+
+質問名を設定します
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | java.lang.String | 質問名 |
+
+### setTop(double value) {#setTop-double}
+```
+public final void setTop(double value)
+```
+
+
+質問の上位置を取得または設定します
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | double | 上 |
+
+### setWidth(double value) {#setWidth-double}
+```
+public final void setWidth(double value)
+```
+
+
+質問の幅を取得または設定します
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | double | 幅 |
+
+### toString() {#toString}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/japanese/java/com.aspose.omr/omrengine/_index.md
+++ b/japanese/java/com.aspose.omr/omrengine/_index.md
@@ -1,0 +1,236 @@
+---
+title: "OmrEngine"
+second_title: "Aspose.OMR for Java API リファレンス"
+description: "OMR エンジン"
+type: docs
+weight: 22
+url: /ja/java/com.aspose.omr/omrengine/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public class OmrEngine
+```
+
+OMR エンジン。テンプレートと画像処理クラスおよび GUI コンポーネントの作成を処理します。
+## コンストラクタ
+
+| コンストラクタ | 説明 |
+| --- | --- |
+| [OmrEngine()](#OmrEngine) |  |
+## メソッド
+
+| メソッド | 説明 |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object) |  |
+| [generateTemplate(String markupPath)](#generateTemplate-java.lang.String) | テキストマークアップに基づいてテンプレート（.omr）とテンプレート画像を作成します |
+| [generateTemplate(String markupPath, GlobalPageSettings settings)](#generateTemplate-java.lang.String-com.aspose.omr.GlobalPageSettings) | テキストマークアップに基づいてテンプレート（.omr）とテンプレート画像を作成します |
+| [generateTemplate(String markupPath, ImageCollection collection)](#generateTemplate-java.lang.String-com.aspose.omr.ImageCollection) | テキストマークアップに基づいてテンプレート（.omr）とテンプレート画像を作成します |
+| [generateTemplate(String markupPath, ImageCollection collection, GlobalPageSettings settings)](#generateTemplate-java.lang.String-com.aspose.omr.ImageCollection-com.aspose.omr.GlobalPageSettings) | テキストマークアップに基づいてテンプレート（.omr）とテンプレート画像を作成します |
+| [getClass()](#getClass) |  |
+| [getTemplateProcessor(InputStream inputStream)](#getTemplateProcessor-java.io.InputStream) | 指定されたテンプレートで作業できる [TemplateProcessor](../../com.aspose.omr/templateprocessor/) インスタンスを作成します。 |
+| [getTemplateProcessor(String templatePath)](#getTemplateProcessor-java.lang.String) | 指定されたテンプレートで作業できる [TemplateProcessor](../../com.aspose.omr/templateprocessor/) インスタンスを作成します。 |
+| [hashCode()](#hashCode) |  |
+| [notify()](#notify) |  |
+| [notifyAll()](#notifyAll) |  |
+| [toString()](#toString) |  |
+| [wait()](#wait) |  |
+| [wait(long arg0)](#wait-long) |  |
+| [wait(long arg0, int arg1)](#wait-long-int) |  |
+### OmrEngine() {#OmrEngine}
+```
+public OmrEngine()
+```
+
+
+### equals(Object arg0) {#equals-java.lang.Object}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### generateTemplate(String markupPath) {#generateTemplate-java.lang.String}
+```
+public final GenerationResult generateTemplate(String markupPath)
+```
+
+
+テキストマークアップに基づいてテンプレート（.omr）とテンプレート画像を作成します
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| markupPath | java.lang.String | テキストマークアップファイルへのパス |
+
+**Returns:**
+[GenerationResult](../../com.aspose.omr/generationresult/) - Generation result
+### generateTemplate(String markupPath, GlobalPageSettings settings) {#generateTemplate-java.lang.String-com.aspose.omr.GlobalPageSettings}
+```
+public final GenerationResult generateTemplate(String markupPath, GlobalPageSettings settings)
+```
+
+
+テキストマークアップに基づいてテンプレート（.omr）とテンプレート画像を作成します
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| markupPath | java.lang.String | テキストマークアップファイルへのパス |
+| settings | [GlobalPageSettings](../../com.aspose.omr/globalpagesettings/) | 各ページのグローバル設定 |
+
+**Returns:**
+[GenerationResult](../../com.aspose.omr/generationresult/) - Generation result
+### generateTemplate(String markupPath, ImageCollection collection) {#generateTemplate-java.lang.String-com.aspose.omr.ImageCollection}
+```
+public final GenerationResult generateTemplate(String markupPath, ImageCollection collection)
+```
+
+
+テキストマークアップに基づいてテンプレート（.omr）とテンプレート画像を作成します
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| markupPath | java.lang.String | テキストマークアップファイルへのパス |
+| collection | [ImageCollection](../../com.aspose.omr/imagecollection/) | このテンプレート生成で使用される画像のコレクション |
+
+**Returns:**
+[GenerationResult](../../com.aspose.omr/generationresult/) - Generation result
+### generateTemplate(String markupPath, ImageCollection collection, GlobalPageSettings settings) {#generateTemplate-java.lang.String-com.aspose.omr.ImageCollection-com.aspose.omr.GlobalPageSettings}
+```
+public final GenerationResult generateTemplate(String markupPath, ImageCollection collection, GlobalPageSettings settings)
+```
+
+
+テキストマークアップに基づいてテンプレート（.omr）とテンプレート画像を作成します
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| markupPath | java.lang.String | テキストマークアップファイルへのパス |
+| collection | [ImageCollection](../../com.aspose.omr/imagecollection/) | このテンプレート生成で使用される画像のコレクション |
+| settings | [GlobalPageSettings](../../com.aspose.omr/globalpagesettings/) | 各ページのグローバル設定 |
+
+**Returns:**
+[GenerationResult](../../com.aspose.omr/generationresult/) - Generation result
+### getClass() {#getClass}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getTemplateProcessor(InputStream inputStream) {#getTemplateProcessor-java.io.InputStream}
+```
+public final TemplateProcessor getTemplateProcessor(InputStream inputStream)
+```
+
+
+指定されたテンプレートで作業できる [TemplateProcessor](../../com.aspose.omr/templateprocessor/) インスタンスを作成します。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| inputStream | java.io.InputStream | OMRテンプレートファイルのコンテンツストリーム |
+
+**Returns:**
+[TemplateProcessor](../../com.aspose.omr/templateprocessor/) - The [TemplateProcessor](../../com.aspose.omr/templateprocessor/) instance
+### getTemplateProcessor(String templatePath) {#getTemplateProcessor-java.lang.String}
+```
+public final TemplateProcessor getTemplateProcessor(String templatePath)
+```
+
+
+指定されたテンプレートで作業できる [TemplateProcessor](../../com.aspose.omr/templateprocessor/) インスタンスを作成します。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| templatePath | java.lang.String | OMRテンプレートファイルへのパス |
+
+**Returns:**
+[TemplateProcessor](../../com.aspose.omr/templateprocessor/) - The [TemplateProcessor](../../com.aspose.omr/templateprocessor/) instance
+### hashCode() {#hashCode}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/japanese/java/com.aspose.omr/omrimage/_index.md
+++ b/japanese/java/com.aspose.omr/omrimage/_index.md
@@ -1,0 +1,148 @@
+---
+title: "OmrImage"
+second_title: "Aspose.OMR for Java API リファレンス"
+description: 
+type: docs
+weight: 23
+url: /ja/java/com.aspose.omr/omrimage/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public class OmrImage
+```
+## コンストラクタ
+
+| コンストラクタ | 説明 |
+| --- | --- |
+| [OmrImage()](#OmrImage) |  |
+## メソッド
+
+| メソッド | 説明 |
+| --- | --- |
+| [Save(String filename)](#Save-java.lang.String) |  |
+| [equals(Object arg0)](#equals-java.lang.Object) |  |
+| [getClass()](#getClass) |  |
+| [hashCode()](#hashCode) |  |
+| [notify()](#notify) |  |
+| [notifyAll()](#notifyAll) |  |
+| [toString()](#toString) |  |
+| [wait()](#wait) |  |
+| [wait(long arg0)](#wait-long) |  |
+| [wait(long arg0, int arg1)](#wait-long-int) |  |
+### OmrImage() {#OmrImage}
+```
+public OmrImage()
+```
+
+
+### Save(String filename) {#Save-java.lang.String}
+```
+public void Save(String filename)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| ファイル名 | java.lang.String |  |
+
+### equals(Object arg0) {#equals-java.lang.Object}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### hashCode() {#hashCode}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/japanese/java/com.aspose.omr/omrpage/_index.md
+++ b/japanese/java/com.aspose.omr/omrpage/_index.md
@@ -1,0 +1,390 @@
+---
+title: "OmrPage"
+second_title: "Aspose.OMR for Java API リファレンス"
+description: "単一の OMR ページを表します"
+type: docs
+weight: 24
+url: /ja/java/com.aspose.omr/omrpage/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public class OmrPage
+```
+
+単一の OMR ページを表します
+## コンストラクタ
+
+| コンストラクタ | 説明 |
+| --- | --- |
+| [OmrPage()](#OmrPage) | 新しい [OmrPage](../../com.aspose.omr/omrpage/) クラスのインスタンスを初期化します |
+## メソッド
+
+| メソッド | 説明 |
+| --- | --- |
+| [addBarcodeElement(BarcodeElement element)](#addBarcodeElement-com.aspose.omr.BarcodeElement) |  |
+| [addChoiceBoxElement(String name, int width, int height, int top, int left)](#addChoiceBoxElement-java.lang.String-int-int-int-int) | ページに選択ボックス要素を追加します |
+| [addClipAreaElement(String name, int width, int height, int top, int left)](#addClipAreaElement-java.lang.String-int-int-int-int) |  |
+| [addGridElement(GridElement grid)](#addGridElement-com.aspose.omr.GridElement) |  |
+| [addGridElement(String name, int width, int height, int top, int left)](#addGridElement-java.lang.String-int-int-int-int) |  |
+| [addRefPointElement(ReferencePointElement item)](#addRefPointElement-com.aspose.omr.ReferencePointElement) |  |
+| [equals(Object arg0)](#equals-java.lang.Object) |  |
+| [getClass()](#getClass) |  |
+| [getElements()](#getElements) | ページ上の要素リストを取得または設定します |
+| [getHeight()](#getHeight) | ページの高さを取得または設定します |
+| [getImageFormat()](#getImageFormat) | 画像ファイル形式を取得または設定します |
+| [getImageName()](#getImageName) | 画像データを取得または設定します |
+| [getRotationPointPosition()](#getRotationPointPosition) | RotationPointPosition を取得または設定します |
+| [getWidth()](#getWidth) | ページの幅を取得または設定します |
+| [hashCode()](#hashCode) |  |
+| [notify()](#notify) |  |
+| [notifyAll()](#notifyAll) |  |
+| [setElements(System.Collections.Generic.List<OmrElement> value)](#setElements-com.aspose.ms.System.Collections.Generic.List-com.aspose.omr.OmrElement) | ページ上の要素リストを取得または設定します |
+| [setHeight(double value)](#setHeight-double) | ページの高さを取得または設定します |
+| [setImageFormat(String value)](#setImageFormat-java.lang.String) | 画像ファイル形式を取得または設定します |
+| [setImageName(String value)](#setImageName-java.lang.String) | 画像名を取得または設定します |
+| [setRotationPointPosition(RotationPointPosition value)](#setRotationPointPosition-com.aspose.omr.RotationPointPosition) | RotationPointPosition を取得または設定します |
+| [setWidth(double value)](#setWidth-double) | ページの幅を取得または設定します |
+| [toString()](#toString) |  |
+| [wait()](#wait) |  |
+| [wait(long arg0)](#wait-long) |  |
+| [wait(long arg0, int arg1)](#wait-long-int) |  |
+### OmrPage() {#OmrPage}
+```
+public OmrPage()
+```
+
+
+新しい [OmrPage](../../com.aspose.omr/omrpage/) クラスのインスタンスを初期化します
+
+### addBarcodeElement(BarcodeElement element) {#addBarcodeElement-com.aspose.omr.BarcodeElement}
+```
+public final void addBarcodeElement(BarcodeElement element)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| element | [BarcodeElement](../../com.aspose.omr/barcodeelement/) |  |
+
+### addChoiceBoxElement(String name, int width, int height, int top, int left) {#addChoiceBoxElement-java.lang.String-int-int-int-int}
+```
+public final ChoiceBoxElement addChoiceBoxElement(String name, int width, int height, int top, int left)
+```
+
+
+ページに選択ボックス要素を追加します
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 名前 | java.lang.String | 要素名 |
+| 幅 | int | 要素の幅 |
+| 高さ | int | 要素の高さ |
+| 上 | int | 要素の上位置 |
+| 左 | int | 要素の左位置 |
+
+**Returns:**
+[ChoiceBoxElement](../../com.aspose.omr/choiceboxelement/) - Created choice box
+### addClipAreaElement(String name, int width, int height, int top, int left) {#addClipAreaElement-java.lang.String-int-int-int-int}
+```
+public final ClipAreaElement addClipAreaElement(String name, int width, int height, int top, int left)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 名前 | java.lang.String |  |
+| 幅 | int |  |
+| 高さ | int |  |
+| 上 | int |  |
+| 左 | int |  |
+
+**Returns:**
+[ClipAreaElement](../../com.aspose.omr/clipareaelement/)
+### addGridElement(GridElement grid) {#addGridElement-com.aspose.omr.GridElement}
+```
+public final void addGridElement(GridElement grid)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| grid | [GridElement](../../com.aspose.omr/gridelement/) |  |
+
+### addGridElement(String name, int width, int height, int top, int left) {#addGridElement-java.lang.String-int-int-int-int}
+```
+public final GridElement addGridElement(String name, int width, int height, int top, int left)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 名前 | java.lang.String |  |
+| 幅 | int |  |
+| 高さ | int |  |
+| 上 | int |  |
+| 左 | int |  |
+
+**Returns:**
+[GridElement](../../com.aspose.omr/gridelement/)
+### addRefPointElement(ReferencePointElement item) {#addRefPointElement-com.aspose.omr.ReferencePointElement}
+```
+public final void addRefPointElement(ReferencePointElement item)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| item | [ReferencePointElement](../../com.aspose.omr/referencepointelement/) |  |
+
+### equals(Object arg0) {#equals-java.lang.Object}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getElements() {#getElements}
+```
+public final System.Collections.Generic.List<OmrElement> getElements()
+```
+
+
+ページ上の要素リストを取得または設定します
+
+**Returns:**
+com.aspose.ms.System.Collections.Generic.List<com.aspose.omr.OmrElement> - ページ上の要素のリスト
+### getHeight() {#getHeight}
+```
+public final double getHeight()
+```
+
+
+ページの高さを取得または設定します
+
+**Returns:**
+double - ページの高さ
+### getImageFormat() {#getImageFormat}
+```
+public final String getImageFormat()
+```
+
+
+画像ファイル形式を取得または設定します
+
+**Returns:**
+java.lang.String - 画像ファイル形式
+### getImageName() {#getImageName}
+```
+public final String getImageName()
+```
+
+
+画像データを取得または設定します
+
+**Returns:**
+java.lang.String - 画像名
+### getRotationPointPosition() {#getRotationPointPosition}
+```
+public final RotationPointPosition getRotationPointPosition()
+```
+
+
+RotationPointPosition を取得または設定します
+
+**Returns:**
+[RotationPointPosition](../../com.aspose.omr/rotationpointposition/) - RotationPointPosition
+### getWidth() {#getWidth}
+```
+public final double getWidth()
+```
+
+
+ページの幅を取得または設定します
+
+**Returns:**
+double - ページの幅
+### hashCode() {#hashCode}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setElements(System.Collections.Generic.List<OmrElement> value) {#setElements-com.aspose.ms.System.Collections.Generic.List-com.aspose.omr.OmrElement}
+```
+public final void setElements(System.Collections.Generic.List<OmrElement> value)
+```
+
+
+ページ上の要素リストを取得または設定します
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | com.aspose.ms.System.Collections.Generic.List<com.aspose.omr.OmrElement> | ページ上の要素のリスト |
+
+### setHeight(double value) {#setHeight-double}
+```
+public final void setHeight(double value)
+```
+
+
+ページの高さを取得または設定します
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | double | ページの高さ |
+
+### setImageFormat(String value) {#setImageFormat-java.lang.String}
+```
+public final void setImageFormat(String value)
+```
+
+
+画像ファイル形式を取得または設定します
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | java.lang.String | 画像ファイル形式 |
+
+### setImageName(String value) {#setImageName-java.lang.String}
+```
+public final void setImageName(String value)
+```
+
+
+画像名を取得または設定します
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | java.lang.String | 画像名 |
+
+### setRotationPointPosition(RotationPointPosition value) {#setRotationPointPosition-com.aspose.omr.RotationPointPosition}
+```
+public final void setRotationPointPosition(RotationPointPosition value)
+```
+
+
+RotationPointPosition を取得または設定します
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| value | [RotationPointPosition](../../com.aspose.omr/rotationpointposition/) | RotationPointPosition |
+
+### setWidth(double value) {#setWidth-double}
+```
+public final void setWidth(double value)
+```
+
+
+ページの幅を取得または設定します
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | double | ページ幅 |
+
+### toString() {#toString}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/japanese/java/com.aspose.omr/omrtemplate/_index.md
+++ b/japanese/java/com.aspose.omr/omrtemplate/_index.md
@@ -1,0 +1,287 @@
+---
+title: "OmrTemplate"
+second_title: "Aspose.OMR for Java API リファレンス"
+description: "OMR テンプレートを表します"
+type: docs
+weight: 25
+url: /ja/java/com.aspose.omr/omrtemplate/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public class OmrTemplate
+```
+
+OMR テンプレートを表します
+## コンストラクタ
+
+| コンストラクタ | 説明 |
+| --- | --- |
+| [OmrTemplate()](#OmrTemplate) | 新しい [OmrTemplate](../../com.aspose.omr/omrtemplate/) クラスのインスタンスを初期化します |
+## フィールド
+
+| フィールド | 説明 |
+| --- | --- |
+| [Version](#Version) | テンプレートのマークアップバージョンを取得または設定します |
+## メソッド
+
+| メソッド | 説明 |
+| --- | --- |
+| [addPage()](#addPage) | テンプレートにページを追加します |
+| [equals(Object arg0)](#equals-java.lang.Object) |  |
+| [getClass()](#getClass) |  |
+| [getFinalizationComplete()](#getFinalizationComplete) |  |
+| [getName()](#getName) | テンプレート名を取得または設定します |
+| [getPages()](#getPages) | テンプレート内のページのリストを取得します |
+| [getTemplateId()](#getTemplateId) |  |
+| [hashCode()](#hashCode) |  |
+| [isGenerated()](#isGenerated) |  |
+| [notify()](#notify) |  |
+| [notifyAll()](#notifyAll) |  |
+| [setFinalizationComplete(boolean value)](#setFinalizationComplete-boolean) |  |
+| [setGenerated(boolean value)](#setGenerated-boolean) |  |
+| [setName(String value)](#setName-java.lang.String) | テンプレート名を取得または設定します |
+| [setPages(System.Collections.Generic.List<OmrPage> value)](#setPages-com.aspose.ms.System.Collections.Generic.List-com.aspose.omr.OmrPage) | テンプレート内のページのリストを設定します |
+| [setTemplateId(String value)](#setTemplateId-java.lang.String) |  |
+| [toString()](#toString) |  |
+| [wait()](#wait) |  |
+| [wait(long arg0)](#wait-long) |  |
+| [wait(long arg0, int arg1)](#wait-long-int) |  |
+### OmrTemplate() {#OmrTemplate}
+```
+public OmrTemplate()
+```
+
+
+新しい [OmrTemplate](../../com.aspose.omr/omrtemplate/) クラスのインスタンスを初期化します
+
+### Version {#Version}
+```
+public final String Version
+```
+
+
+テンプレートのマークアップバージョンを取得または設定します
+
+### addPage() {#addPage}
+```
+public final OmrPage addPage()
+```
+
+
+テンプレートにページを追加します
+
+**Returns:**
+[OmrPage](../../com.aspose.omr/omrpage/) - Created page
+### equals(Object arg0) {#equals-java.lang.Object}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getFinalizationComplete() {#getFinalizationComplete}
+```
+public final boolean getFinalizationComplete()
+```
+
+
+
+
+**Returns:**
+boolean
+### getName() {#getName}
+```
+public final String getName()
+```
+
+
+テンプレート名を取得または設定します
+
+**Returns:**
+java.lang.String - テンプレート名
+### getPages() {#getPages}
+```
+public final System.Collections.Generic.List<OmrPage> getPages()
+```
+
+
+テンプレート内のページのリストを取得します
+
+**Returns:**
+com.aspose.ms.System.Collections.Generic.List<com.aspose.omr.OmrPage> - テンプレート内のページのリスト
+### getTemplateId() {#getTemplateId}
+```
+public final String getTemplateId()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### hashCode() {#hashCode}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### isGenerated() {#isGenerated}
+```
+public final boolean isGenerated()
+```
+
+
+
+
+**Returns:**
+boolean
+### notify() {#notify}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setFinalizationComplete(boolean value) {#setFinalizationComplete-boolean}
+```
+public final void setFinalizationComplete(boolean value)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | boolean |  |
+
+### setGenerated(boolean value) {#setGenerated-boolean}
+```
+public final void setGenerated(boolean value)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | boolean |  |
+
+### setName(String value) {#setName-java.lang.String}
+```
+public final void setName(String value)
+```
+
+
+テンプレート名を取得または設定します
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | java.lang.String | テンプレート名 |
+
+### setPages(System.Collections.Generic.List<OmrPage> value) {#setPages-com.aspose.ms.System.Collections.Generic.List-com.aspose.omr.OmrPage}
+```
+public final void setPages(System.Collections.Generic.List<OmrPage> value)
+```
+
+
+テンプレート内のページのリストを設定します
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | com.aspose.ms.System.Collections.Generic.List<com.aspose.omr.OmrPage> | テンプレート内のページのリスト |
+
+### setTemplateId(String value) {#setTemplateId-java.lang.String}
+```
+public final void setTemplateId(String value)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | java.lang.String |  |
+
+### toString() {#toString}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/japanese/java/com.aspose.omr/orientations/_index.md
+++ b/japanese/java/com.aspose.omr/orientations/_index.md
@@ -1,0 +1,568 @@
+---
+title: "向き"
+second_title: "Aspose.OMR for Java API リファレンス"
+description: "可能な質問の向き"
+type: docs
+weight: 26
+url: /ja/java/com.aspose.omr/orientations/
+---
+
+**Inheritance:**
+java.lang.Object, com.aspose.ms.System.ValueType, com.aspose.ms.System.Enum
+```
+public final class Orientations extends System.Enum
+```
+
+可能な質問の向き
+## フィールド
+
+| フィールド | 説明 |
+| --- | --- |
+| [EnumSeparatorCharArray](#EnumSeparatorCharArray) |  |
+| [Horizontal](#Horizontal) | 水平向き |
+| [Vertical](#Vertical) | 垂直向き |
+## メソッド
+
+| メソッド | 説明 |
+| --- | --- |
+| [Clone()](#Clone) |  |
+| [CloneTo(T arg0)](#CloneTo-T) |  |
+| [CloneTo(System.Enum arg0)](#CloneTo-com.aspose.ms.System.Enum) |  |
+| [equals(Object arg0)](#equals-java.lang.Object) |  |
+| [format(System.Type arg0, Object arg1, String arg2)](#format-com.aspose.ms.System.Type-java.lang.Object-java.lang.String) |  |
+| [format(Class<?> arg0, long arg1, String arg2)](#format-java.lang.Class----long-java.lang.String) |  |
+| [getClass()](#getClass) |  |
+| [getName(System.Type arg0, Object arg1)](#getName-com.aspose.ms.System.Type-java.lang.Object) |  |
+| [getName(Class<?> arg0, long arg1)](#getName-java.lang.Class----long) |  |
+| [getNames(System.Type arg0)](#getNames-com.aspose.ms.System.Type) |  |
+| [getNames(Class<?> arg0)](#getNames-java.lang.Class) |  |
+| [getUnderlyingType(System.Type arg0)](#getUnderlyingType-com.aspose.ms.System.Type) |  |
+| [getUnderlyingType(Class<?> arg0)](#getUnderlyingType-java.lang.Class) |  |
+| [getValue(Class<?> arg0, String arg1)](#getValue-java.lang.Class----java.lang.String) |  |
+| [getValues(System.Type arg0)](#getValues-com.aspose.ms.System.Type) |  |
+| [get_Caption()](#get-Caption) |  |
+| [get_Value()](#get-Value) |  |
+| [hashCode()](#hashCode) |  |
+| [isDefined(System.Type arg0, Object arg1)](#isDefined-com.aspose.ms.System.Type-java.lang.Object) |  |
+| [isDefined(System.Type arg0, String arg1)](#isDefined-com.aspose.ms.System.Type-java.lang.String) |  |
+| [isDefined(System.Type arg0, long arg1)](#isDefined-com.aspose.ms.System.Type-long) |  |
+| [isDefined(Class<?> arg0, long arg1)](#isDefined-java.lang.Class----long) |  |
+| [notify()](#notify) |  |
+| [notifyAll()](#notifyAll) |  |
+| [parse(System.Type arg0, String arg1)](#parse-com.aspose.ms.System.Type-java.lang.String) |  |
+| [parse(System.Type arg0, String arg1, Boolean arg2)](#parse-com.aspose.ms.System.Type-java.lang.String-java.lang.Boolean) |  |
+| [parse(Class<?> arg0, String arg1)](#parse-java.lang.Class----java.lang.String) |  |
+| [parse(Class<?> arg0, String arg1, Boolean arg2)](#parse-java.lang.Class----java.lang.String-java.lang.Boolean) |  |
+| [register(System.Enum.AbstractEnum arg0)](#register-com.aspose.ms.System.Enum.AbstractEnum) |  |
+| [toObject(System.Type arg0, Object arg1)](#toObject-com.aspose.ms.System.Type-java.lang.Object) |  |
+| [toString()](#toString) |  |
+| [toString(Class<?> arg0, long arg1)](#toString-java.lang.Class----long) |  |
+| [wait()](#wait) |  |
+| [wait(long arg0)](#wait-long) |  |
+| [wait(long arg0, int arg1)](#wait-long-int) |  |
+### EnumSeparatorCharArray {#EnumSeparatorCharArray}
+```
+public static final char[] EnumSeparatorCharArray
+```
+
+
+### Horizontal {#Horizontal}
+```
+public static final int Horizontal
+```
+
+
+水平向き
+
+### Vertical {#Vertical}
+```
+public static final int Vertical
+```
+
+
+垂直向き
+
+### Clone() {#Clone}
+```
+public System.Enum Clone()
+```
+
+
+
+
+**Returns:**
+com.aspose.ms.System.Enum
+### CloneTo(T arg0) {#CloneTo-T}
+```
+public abstract void CloneTo(T arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | T |  |
+
+### CloneTo(System.Enum arg0) {#CloneTo-com.aspose.ms.System.Enum}
+```
+public void CloneTo(System.Enum arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | com.aspose.ms.System.Enum |  |
+
+### equals(Object arg0) {#equals-java.lang.Object}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### format(System.Type arg0, Object arg1, String arg2) {#format-com.aspose.ms.System.Type-java.lang.Object-java.lang.String}
+```
+public static String format(System.Type arg0, Object arg1, String arg2)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | com.aspose.ms.System.Type |  |
+| arg1 | java.lang.Object |  |
+| arg2 | java.lang.String |  |
+
+**Returns:**
+java.lang.String
+### format(Class<?> arg0, long arg1, String arg2) {#format-java.lang.Class----long-java.lang.String}
+```
+public static String format(Class<?> arg0, long arg1, String arg2)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | java.lang.Class<?> |  |
+| arg1 | long |  |
+| arg2 | java.lang.String |  |
+
+**Returns:**
+java.lang.String
+### getClass() {#getClass}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getName(System.Type arg0, Object arg1) {#getName-com.aspose.ms.System.Type-java.lang.Object}
+```
+public static String getName(System.Type arg0, Object arg1)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | com.aspose.ms.System.Type |  |
+| arg1 | java.lang.Object |  |
+
+**Returns:**
+java.lang.String
+### getName(Class<?> arg0, long arg1) {#getName-java.lang.Class----long}
+```
+public static String getName(Class<?> arg0, long arg1)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | java.lang.Class<?> |  |
+| arg1 | long |  |
+
+**Returns:**
+java.lang.String
+### getNames(System.Type arg0) {#getNames-com.aspose.ms.System.Type}
+```
+public static String[] getNames(System.Type arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | com.aspose.ms.System.Type |  |
+
+**Returns:**
+java.lang.String[]
+### getNames(Class<?> arg0) {#getNames-java.lang.Class}
+```
+public static Collection<String> getNames(Class<?> arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | java.lang.Class<?> |  |
+
+**Returns:**
+java.util.Collection<java.lang.String>
+### getUnderlyingType(System.Type arg0) {#getUnderlyingType-com.aspose.ms.System.Type}
+```
+public static System.Type getUnderlyingType(System.Type arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | com.aspose.ms.System.Type |  |
+
+**Returns:**
+com.aspose.ms.System.Type
+### getUnderlyingType(Class<?> arg0) {#getUnderlyingType-java.lang.Class}
+```
+public static Class<? extends Number> getUnderlyingType(Class<?> arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | java.lang.Class<?> |  |
+
+**Returns:**
+java.lang.Class<? extends java.lang.Number>
+### getValue(Class<?> arg0, String arg1) {#getValue-java.lang.Class----java.lang.String}
+```
+public static long getValue(Class<?> arg0, String arg1)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | java.lang.Class<?> |  |
+| arg1 | java.lang.String |  |
+
+**Returns:**
+long
+### getValues(System.Type arg0) {#getValues-com.aspose.ms.System.Type}
+```
+public static System.Array getValues(System.Type arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | com.aspose.ms.System.Type |  |
+
+**Returns:**
+com.aspose.ms.System.Array
+### get_Caption() {#get-Caption}
+```
+public String get_Caption()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### get_Value() {#get-Value}
+```
+public long get_Value()
+```
+
+
+
+
+**Returns:**
+long
+### hashCode() {#hashCode}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### isDefined(System.Type arg0, Object arg1) {#isDefined-com.aspose.ms.System.Type-java.lang.Object}
+```
+public static boolean isDefined(System.Type arg0, Object arg1)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | com.aspose.ms.System.Type |  |
+| arg1 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### isDefined(System.Type arg0, String arg1) {#isDefined-com.aspose.ms.System.Type-java.lang.String}
+```
+public static boolean isDefined(System.Type arg0, String arg1)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | com.aspose.ms.System.Type |  |
+| arg1 | java.lang.String |  |
+
+**Returns:**
+boolean
+### isDefined(System.Type arg0, long arg1) {#isDefined-com.aspose.ms.System.Type-long}
+```
+public static boolean isDefined(System.Type arg0, long arg1)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | com.aspose.ms.System.Type |  |
+| arg1 | long |  |
+
+**Returns:**
+boolean
+### isDefined(Class<?> arg0, long arg1) {#isDefined-java.lang.Class----long}
+```
+public static boolean isDefined(Class<?> arg0, long arg1)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | java.lang.Class<?> |  |
+| arg1 | long |  |
+
+**Returns:**
+boolean
+### notify() {#notify}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### parse(System.Type arg0, String arg1) {#parse-com.aspose.ms.System.Type-java.lang.String}
+```
+public static long parse(System.Type arg0, String arg1)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | com.aspose.ms.System.Type |  |
+| arg1 | java.lang.String |  |
+
+**Returns:**
+long
+### parse(System.Type arg0, String arg1, Boolean arg2) {#parse-com.aspose.ms.System.Type-java.lang.String-java.lang.Boolean}
+```
+public static long parse(System.Type arg0, String arg1, Boolean arg2)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | com.aspose.ms.System.Type |  |
+| arg1 | java.lang.String |  |
+| arg2 | java.lang.Boolean |  |
+
+**Returns:**
+long
+### parse(Class<?> arg0, String arg1) {#parse-java.lang.Class----java.lang.String}
+```
+public static long parse(Class<?> arg0, String arg1)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | java.lang.Class<?> |  |
+| arg1 | java.lang.String |  |
+
+**Returns:**
+long
+### parse(Class<?> arg0, String arg1, Boolean arg2) {#parse-java.lang.Class----java.lang.String-java.lang.Boolean}
+```
+public static long parse(Class<?> arg0, String arg1, Boolean arg2)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | java.lang.Class<?> |  |
+| arg1 | java.lang.String |  |
+| arg2 | java.lang.Boolean |  |
+
+**Returns:**
+long
+### register(System.Enum.AbstractEnum arg0) {#register-com.aspose.ms.System.Enum.AbstractEnum}
+```
+public static void register(System.Enum.AbstractEnum arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | com.aspose.ms.System.Enum.AbstractEnum |  |
+
+### toObject(System.Type arg0, Object arg1) {#toObject-com.aspose.ms.System.Type-java.lang.Object}
+```
+public static Object toObject(System.Type arg0, Object arg1)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | com.aspose.ms.System.Type |  |
+| arg1 | java.lang.Object |  |
+
+**Returns:**
+java.lang.Object
+### toString() {#toString}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### toString(Class<?> arg0, long arg1) {#toString-java.lang.Class----long}
+```
+public static String toString(Class<?> arg0, long arg1)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | java.lang.Class<?> |  |
+| arg1 | long |  |
+
+**Returns:**
+java.lang.String
+### wait() {#wait}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/japanese/java/com.aspose.omr/papersize/_index.md
+++ b/japanese/java/com.aspose.omr/papersize/_index.md
@@ -1,0 +1,276 @@
+---
+title: "用紙サイズ"
+second_title: "Aspose.OMR for Java API リファレンス"
+description: "サポートされている用紙サイズ"
+type: docs
+weight: 37
+url: /ja/java/com.aspose.omr/papersize/
+---
+
+**Inheritance:**
+java.lang.Object, java.lang.Enum
+```
+public enum PaperSize extends Enum<PaperSize>
+```
+
+サポートされている用紙サイズ
+## フィールド
+
+| フィールド | 説明 |
+| --- | --- |
+| [A4](#A4) | A4サイズ（2480 x 3508 ピクセル） |
+| [Legal](#Legal) | リーガルサイズ（2551 x 4205 ピクセル） |
+| [Letter](#Letter) | レターサイズ（2551 x 3295 ピクセル） |
+| [Tabloid](#Tabloid) | タブロイド、11\" x 17\" サイズ（3295 x 5102） |
+| [p8519](#p8519) | 8.5\" x 19\" サイズ（2551 x 5702） |
+| [p8521](#p8521) | 8.5 x 21\" サイズ（2551 x 6302） |
+## メソッド
+
+| メソッド | 説明 |
+| --- | --- |
+| [<T>valueOf(Class<T> arg0, String arg1)](#-T-valueOf-java.lang.Class-T--java.lang.String) |  |
+| [compareTo(E arg0)](#compareTo-E) |  |
+| [equals(Object arg0)](#equals-java.lang.Object) |  |
+| [getClass()](#getClass) |  |
+| [getDeclaringClass()](#getDeclaringClass) |  |
+| [hashCode()](#hashCode) |  |
+| [name()](#name) |  |
+| [notify()](#notify) |  |
+| [notifyAll()](#notifyAll) |  |
+| [ordinal()](#ordinal) |  |
+| [toString()](#toString) |  |
+| [valueOf(String name)](#valueOf-java.lang.String) |  |
+| [values()](#values) |  |
+| [wait()](#wait) |  |
+| [wait(long arg0)](#wait-long) |  |
+| [wait(long arg0, int arg1)](#wait-long-int) |  |
+### A4 {#A4}
+```
+public static final PaperSize A4
+```
+
+
+A4サイズ（2480 x 3508 ピクセル）
+
+### Legal {#Legal}
+```
+public static final PaperSize Legal
+```
+
+
+リーガルサイズ（2551 x 4205 ピクセル）
+
+### Letter {#Letter}
+```
+public static final PaperSize Letter
+```
+
+
+レターサイズ（2551 x 3295 ピクセル）
+
+### Tabloid {#Tabloid}
+```
+public static final PaperSize Tabloid
+```
+
+
+タブロイド、11\" x 17\" サイズ（3295 x 5102）
+
+### p8519 {#p8519}
+```
+public static final PaperSize p8519
+```
+
+
+8.5\" x 19\" サイズ（2551 x 5702）
+
+### p8521 {#p8521}
+```
+public static final PaperSize p8521
+```
+
+
+8.5 x 21\" サイズ（2551 x 6302）
+
+### <T>valueOf(Class<T> arg0, String arg1) {#-T-valueOf-java.lang.Class-T--java.lang.String}
+```
+public static T <T>valueOf(Class<T> arg0, String arg1)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | java.lang.Class<T> |  |
+| arg1 | java.lang.String |  |
+
+**Returns:**
+T
+### compareTo(E arg0) {#compareTo-E}
+```
+public final int compareTo(E arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | E |  |
+
+**Returns:**
+int
+### equals(Object arg0) {#equals-java.lang.Object}
+```
+public final boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getDeclaringClass() {#getDeclaringClass}
+```
+public final Class<E> getDeclaringClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<E>
+### hashCode() {#hashCode}
+```
+public final int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### name() {#name}
+```
+public final String name()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### notify() {#notify}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### ordinal() {#ordinal}
+```
+public final int ordinal()
+```
+
+
+
+
+**Returns:**
+int
+### toString() {#toString}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### valueOf(String name) {#valueOf-java.lang.String}
+```
+public static PaperSize valueOf(String name)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 名前 | java.lang.String |  |
+
+**Returns:**
+[PaperSize](../../com.aspose.omr/papersize/)
+### values() {#values}
+```
+public static PaperSize[] values()
+```
+
+
+
+
+**Returns:**
+com.aspose.omr.PaperSize[]
+### wait() {#wait}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/japanese/java/com.aspose.omr/qrversion/_index.md
+++ b/japanese/java/com.aspose.omr/qrversion/_index.md
@@ -1,0 +1,535 @@
+---
+title: "QrVersion"
+second_title: "Aspose.OMR for Java API リファレンス"
+description: 
+type: docs
+weight: 38
+url: /ja/java/com.aspose.omr/qrversion/
+---
+
+**Inheritance:**
+java.lang.Object, java.lang.Enum
+```
+public enum QrVersion extends Enum<QrVersion>
+```
+## フィールド
+
+| フィールド | 説明 |
+| --- | --- |
+| [Auto](#Auto) |  |
+| [Version01](#Version01) |  |
+| [Version02](#Version02) |  |
+| [Version03](#Version03) |  |
+| [Version04](#Version04) |  |
+| [Version05](#Version05) |  |
+| [Version06](#Version06) |  |
+| [Version07](#Version07) |  |
+| [Version08](#Version08) |  |
+| [Version09](#Version09) |  |
+| [Version10](#Version10) |  |
+| [Version11](#Version11) |  |
+| [Version12](#Version12) |  |
+| [Version13](#Version13) |  |
+| [Version14](#Version14) |  |
+| [Version15](#Version15) |  |
+| [Version16](#Version16) |  |
+| [Version17](#Version17) |  |
+| [Version18](#Version18) |  |
+| [Version19](#Version19) |  |
+| [Version20](#Version20) |  |
+| [Version21](#Version21) |  |
+| [Version22](#Version22) |  |
+| [Version23](#Version23) |  |
+| [Version24](#Version24) |  |
+| [Version25](#Version25) |  |
+| [Version26](#Version26) |  |
+| [Version27](#Version27) |  |
+| [Version28](#Version28) |  |
+| [Version29](#Version29) |  |
+| [Version30](#Version30) |  |
+| [Version31](#Version31) |  |
+| [Version32](#Version32) |  |
+| [Version33](#Version33) |  |
+| [Version34](#Version34) |  |
+| [Version35](#Version35) |  |
+| [Version36](#Version36) |  |
+| [Version37](#Version37) |  |
+| [Version38](#Version38) |  |
+| [Version39](#Version39) |  |
+| [Version40](#Version40) |  |
+| [VersionM1](#VersionM1) |  |
+| [VersionM2](#VersionM2) |  |
+| [VersionM3](#VersionM3) |  |
+| [VersionM4](#VersionM4) |  |
+## メソッド
+
+| メソッド | 説明 |
+| --- | --- |
+| [<T>valueOf(Class<T> arg0, String arg1)](#-T-valueOf-java.lang.Class-T--java.lang.String) |  |
+| [compareTo(E arg0)](#compareTo-E) |  |
+| [equals(Object arg0)](#equals-java.lang.Object) |  |
+| [getClass()](#getClass) |  |
+| [getDeclaringClass()](#getDeclaringClass) |  |
+| [hashCode()](#hashCode) |  |
+| [name()](#name) |  |
+| [notify()](#notify) |  |
+| [notifyAll()](#notifyAll) |  |
+| [ordinal()](#ordinal) |  |
+| [toString()](#toString) |  |
+| [valueOf(String name)](#valueOf-java.lang.String) |  |
+| [values()](#values) |  |
+| [wait()](#wait) |  |
+| [wait(long arg0)](#wait-long) |  |
+| [wait(long arg0, int arg1)](#wait-long-int) |  |
+### Auto {#Auto}
+```
+public static final QrVersion Auto
+```
+
+
+### Version01 {#Version01}
+```
+public static final QrVersion Version01
+```
+
+
+### Version02 {#Version02}
+```
+public static final QrVersion Version02
+```
+
+
+### Version03 {#Version03}
+```
+public static final QrVersion Version03
+```
+
+
+### Version04 {#Version04}
+```
+public static final QrVersion Version04
+```
+
+
+### Version05 {#Version05}
+```
+public static final QrVersion Version05
+```
+
+
+### Version06 {#Version06}
+```
+public static final QrVersion Version06
+```
+
+
+### Version07 {#Version07}
+```
+public static final QrVersion Version07
+```
+
+
+### Version08 {#Version08}
+```
+public static final QrVersion Version08
+```
+
+
+### Version09 {#Version09}
+```
+public static final QrVersion Version09
+```
+
+
+### Version10 {#Version10}
+```
+public static final QrVersion Version10
+```
+
+
+### Version11 {#Version11}
+```
+public static final QrVersion Version11
+```
+
+
+### Version12 {#Version12}
+```
+public static final QrVersion Version12
+```
+
+
+### Version13 {#Version13}
+```
+public static final QrVersion Version13
+```
+
+
+### Version14 {#Version14}
+```
+public static final QrVersion Version14
+```
+
+
+### Version15 {#Version15}
+```
+public static final QrVersion Version15
+```
+
+
+### Version16 {#Version16}
+```
+public static final QrVersion Version16
+```
+
+
+### Version17 {#Version17}
+```
+public static final QrVersion Version17
+```
+
+
+### Version18 {#Version18}
+```
+public static final QrVersion Version18
+```
+
+
+### Version19 {#Version19}
+```
+public static final QrVersion Version19
+```
+
+
+### Version20 {#Version20}
+```
+public static final QrVersion Version20
+```
+
+
+### Version21 {#Version21}
+```
+public static final QrVersion Version21
+```
+
+
+### Version22 {#Version22}
+```
+public static final QrVersion Version22
+```
+
+
+### Version23 {#Version23}
+```
+public static final QrVersion Version23
+```
+
+
+### Version24 {#Version24}
+```
+public static final QrVersion Version24
+```
+
+
+### Version25 {#Version25}
+```
+public static final QrVersion Version25
+```
+
+
+### Version26 {#Version26}
+```
+public static final QrVersion Version26
+```
+
+
+### Version27 {#Version27}
+```
+public static final QrVersion Version27
+```
+
+
+### Version28 {#Version28}
+```
+public static final QrVersion Version28
+```
+
+
+### Version29 {#Version29}
+```
+public static final QrVersion Version29
+```
+
+
+### Version30 {#Version30}
+```
+public static final QrVersion Version30
+```
+
+
+### Version31 {#Version31}
+```
+public static final QrVersion Version31
+```
+
+
+### Version32 {#Version32}
+```
+public static final QrVersion Version32
+```
+
+
+### Version33 {#Version33}
+```
+public static final QrVersion Version33
+```
+
+
+### Version34 {#Version34}
+```
+public static final QrVersion Version34
+```
+
+
+### Version35 {#Version35}
+```
+public static final QrVersion Version35
+```
+
+
+### Version36 {#Version36}
+```
+public static final QrVersion Version36
+```
+
+
+### Version37 {#Version37}
+```
+public static final QrVersion Version37
+```
+
+
+### Version38 {#Version38}
+```
+public static final QrVersion Version38
+```
+
+
+### Version39 {#Version39}
+```
+public static final QrVersion Version39
+```
+
+
+### Version40 {#Version40}
+```
+public static final QrVersion Version40
+```
+
+
+### VersionM1 {#VersionM1}
+```
+public static final QrVersion VersionM1
+```
+
+
+### VersionM2 {#VersionM2}
+```
+public static final QrVersion VersionM2
+```
+
+
+### VersionM3 {#VersionM3}
+```
+public static final QrVersion VersionM3
+```
+
+
+### VersionM4 {#VersionM4}
+```
+public static final QrVersion VersionM4
+```
+
+
+### <T>valueOf(Class<T> arg0, String arg1) {#-T-valueOf-java.lang.Class-T--java.lang.String}
+```
+public static T <T>valueOf(Class<T> arg0, String arg1)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | java.lang.Class<T> |  |
+| arg1 | java.lang.String |  |
+
+**Returns:**
+T
+### compareTo(E arg0) {#compareTo-E}
+```
+public final int compareTo(E arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | E |  |
+
+**Returns:**
+int
+### equals(Object arg0) {#equals-java.lang.Object}
+```
+public final boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getDeclaringClass() {#getDeclaringClass}
+```
+public final Class<E> getDeclaringClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<E>
+### hashCode() {#hashCode}
+```
+public final int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### name() {#name}
+```
+public final String name()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### notify() {#notify}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### ordinal() {#ordinal}
+```
+public final int ordinal()
+```
+
+
+
+
+**Returns:**
+int
+### toString() {#toString}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### valueOf(String name) {#valueOf-java.lang.String}
+```
+public static QrVersion valueOf(String name)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 名前 | java.lang.String |  |
+
+**Returns:**
+[QrVersion](../../com.aspose.omr/qrversion/)
+### values() {#values}
+```
+public static QrVersion[] values()
+```
+
+
+
+
+**Returns:**
+com.aspose.omr.QrVersion[]
+### wait() {#wait}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/japanese/java/com.aspose.omr/recognitionresult/_index.md
+++ b/japanese/java/com.aspose.omr/recognitionresult/_index.md
@@ -1,0 +1,222 @@
+---
+title: "RecognitionResult"
+second_title: "Aspose.OMR for Java API リファレンス"
+description: "画像認識の結果"
+type: docs
+weight: 27
+url: /ja/java/com.aspose.omr/recognitionresult/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public class RecognitionResult
+```
+
+画像認識の結果。詳細な認識情報と結果エクスポート用のメソッドを含むすべての OMR 要素が含まれます。
+## メソッド
+
+| メソッド | 説明 |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object) |  |
+| [getClass()](#getClass) |  |
+| [getCsv()](#getCsv) | 認識結果の CSV 文字列を作成 |
+| [getImagePath()](#getImagePath) | 処理された画像へのパスを取得または設定します |
+| [getJson()](#getJson) | 認識結果の JSON 文字列を作成 |
+| [getOmrElements()](#getOmrElements) | ページ上の OMR 要素のリストを取得または設定します |
+| [getTemplateName()](#getTemplateName) | OMR テンプレート名を取得または設定します |
+| [hashCode()](#hashCode) |  |
+| [notify()](#notify) |  |
+| [notifyAll()](#notifyAll) |  |
+| [setImagePath(String value)](#setImagePath-java.lang.String) | 処理された画像へのパスを取得または設定します |
+| [setOmrElements(List<IOmrElement> value)](#setOmrElements-java.util.List-com.aspose.omr.IOmrElement) | ページ上の OMR 要素のリストを取得または設定します |
+| [setTemplateName(String value)](#setTemplateName-java.lang.String) | OMR テンプレート名を取得または設定します |
+| [toString()](#toString) |  |
+| [wait()](#wait) |  |
+| [wait(long arg0)](#wait-long) |  |
+| [wait(long arg0, int arg1)](#wait-long-int) |  |
+### equals(Object arg0) {#equals-java.lang.Object}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getCsv() {#getCsv}
+```
+public final String getCsv()
+```
+
+
+認識結果の CSV 文字列を作成
+
+**Returns:**
+java.lang.String - CSV 文字列としての認識結果
+### getImagePath() {#getImagePath}
+```
+public final String getImagePath()
+```
+
+
+処理された画像へのパスを取得または設定します
+
+**Returns:**
+java.lang.String - 処理された画像へのパス
+### getJson() {#getJson}
+```
+public final String getJson()
+```
+
+
+認識結果の JSON 文字列を作成
+
+**Returns:**
+java.lang.String - JSON 文字列としての認識結果
+### getOmrElements() {#getOmrElements}
+```
+public final List<IOmrElement> getOmrElements()
+```
+
+
+ページ上の OMR 要素のリストを取得または設定します
+
+**Returns:**
+java.util.List<com.aspose.omr.IOmrElement>
+### getTemplateName() {#getTemplateName}
+```
+public final String getTemplateName()
+```
+
+
+OMR テンプレート名を取得または設定します
+
+**Returns:**
+java.lang.String - OMR テンプレート名
+### hashCode() {#hashCode}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setImagePath(String value) {#setImagePath-java.lang.String}
+```
+public final void setImagePath(String value)
+```
+
+
+処理された画像へのパスを取得または設定します
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | java.lang.String | 処理された画像へのパス |
+
+### setOmrElements(List<IOmrElement> value) {#setOmrElements-java.util.List-com.aspose.omr.IOmrElement}
+```
+public final void setOmrElements(List<IOmrElement> value)
+```
+
+
+ページ上の OMR 要素のリストを取得または設定します
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | java.util.List<com.aspose.omr.IOmrElement> |  |
+
+### setTemplateName(String value) {#setTemplateName-java.lang.String}
+```
+public final void setTemplateName(String value)
+```
+
+
+OMR テンプレート名を取得または設定します
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | java.lang.String | OMR テンプレート名 |
+
+### toString() {#toString}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/japanese/java/com.aspose.omr/referencepointelement/_index.md
+++ b/japanese/java/com.aspose.omr/referencepointelement/_index.md
@@ -1,0 +1,288 @@
+---
+title: "ReferencePointElement"
+second_title: "Aspose.OMR for Java API リファレンス"
+description: 
+type: docs
+weight: 28
+url: /ja/java/com.aspose.omr/referencepointelement/
+---
+
+**Inheritance:**
+java.lang.Object, [com.aspose.omr.OmrElement](../../com.aspose.omr/omrelement/)
+```
+public class ReferencePointElement extends OmrElement
+```
+## コンストラクタ
+
+| コンストラクタ | 説明 |
+| --- | --- |
+| [ReferencePointElement()](#ReferencePointElement) |  |
+## フィールド
+
+| フィールド | 説明 |
+| --- | --- |
+| [ElementType](#ElementType) |  |
+| [ReferenceType](#ReferenceType) |  |
+## メソッド
+
+| メソッド | 説明 |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object) |  |
+| [getClass()](#getClass) |  |
+| [getHeight()](#getHeight) | 質問の高さを取得または設定します |
+| [getLeft()](#getLeft) | 質問の左位置を取得または設定します |
+| [getName()](#getName) | 質問名を取得します |
+| [getRect()](#getRect) |  |
+| [getTop()](#getTop) | 質問の上位置を取得または設定します |
+| [getWidth()](#getWidth) | 質問の幅を取得または設定します |
+| [hashCode()](#hashCode) |  |
+| [notify()](#notify) |  |
+| [notifyAll()](#notifyAll) |  |
+| [setHeight(double value)](#setHeight-double) | 質問の高さを取得または設定します |
+| [setLeft(double value)](#setLeft-double) | 質問の左位置を取得または設定します |
+| [setName(String value)](#setName-java.lang.String) | 質問名を設定します |
+| [setTop(double value)](#setTop-double) | 質問の上位置を取得または設定します |
+| [setWidth(double value)](#setWidth-double) | 質問の幅を取得または設定します |
+| [toString()](#toString) |  |
+| [wait()](#wait) |  |
+| [wait(long arg0)](#wait-long) |  |
+| [wait(long arg0, int arg1)](#wait-long-int) |  |
+### ReferencePointElement() {#ReferencePointElement}
+```
+public ReferencePointElement()
+```
+
+
+### ElementType {#ElementType}
+```
+public String ElementType
+```
+
+
+### ReferenceType {#ReferenceType}
+```
+public ReferencePointType ReferenceType
+```
+
+
+### equals(Object arg0) {#equals-java.lang.Object}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getHeight() {#getHeight}
+```
+public final double getHeight()
+```
+
+
+質問の高さを取得または設定します
+
+**Returns:**
+double - 高さ
+### getLeft() {#getLeft}
+```
+public final double getLeft()
+```
+
+
+質問の左位置を取得または設定します
+
+**Returns:**
+double - 左
+### getName() {#getName}
+```
+public final String getName()
+```
+
+
+質問名を取得します
+
+**Returns:**
+java.lang.String - 質問名
+### getRect() {#getRect}
+```
+public System.Drawing.RectangleF getRect()
+```
+
+
+
+
+**Returns:**
+com.aspose.ms.System.Drawing.RectangleF
+### getTop() {#getTop}
+```
+public final double getTop()
+```
+
+
+質問の上位置を取得または設定します
+
+**Returns:**
+double - 上
+### getWidth() {#getWidth}
+```
+public final double getWidth()
+```
+
+
+質問の幅を取得または設定します
+
+**Returns:**
+double - 幅
+### hashCode() {#hashCode}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setHeight(double value) {#setHeight-double}
+```
+public final void setHeight(double value)
+```
+
+
+質問の高さを取得または設定します
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | double | 高さ |
+
+### setLeft(double value) {#setLeft-double}
+```
+public final void setLeft(double value)
+```
+
+
+質問の左位置を取得または設定します
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | double | 左 |
+
+### setName(String value) {#setName-java.lang.String}
+```
+public final void setName(String value)
+```
+
+
+質問名を設定します
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | java.lang.String | 質問名 |
+
+### setTop(double value) {#setTop-double}
+```
+public final void setTop(double value)
+```
+
+
+質問の上位置を取得または設定します
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | double | 上 |
+
+### setWidth(double value) {#setWidth-double}
+```
+public final void setWidth(double value)
+```
+
+
+質問の幅を取得または設定します
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | double | 幅 |
+
+### toString() {#toString}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/japanese/java/com.aspose.omr/referencepointssettings/_index.md
+++ b/japanese/java/com.aspose.omr/referencepointssettings/_index.md
@@ -1,0 +1,151 @@
+---
+title: "ReferencePointsSettings"
+second_title: "Aspose.OMR for Java API リファレンス"
+description: "すべてのページ要素に適用される参照ポイントのグローバル設定"
+type: docs
+weight: 29
+url: /ja/java/com.aspose.omr/referencepointssettings/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public class ReferencePointsSettings
+```
+
+すべてのページ要素に適用される参照点のグローバル設定。
+
+テンプレートの参照ポイントの動作を記述する設定（例：角の黒い四角形や回転マーカーの間の黒い長方形）。
+## コンストラクタ
+
+| コンストラクタ | 説明 |
+| --- | --- |
+| [ReferencePointsSettings()](#ReferencePointsSettings) |  |
+## フィールド
+
+| フィールド | 説明 |
+| --- | --- |
+| [RotationMarkerPosition](#RotationMarkerPosition) | テンプレート上の希望する回転マーカー位置。 |
+## メソッド
+
+| メソッド | 説明 |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object) |  |
+| [getClass()](#getClass) |  |
+| [hashCode()](#hashCode) |  |
+| [notify()](#notify) |  |
+| [notifyAll()](#notifyAll) |  |
+| [toString()](#toString) |  |
+| [wait()](#wait) |  |
+| [wait(long arg0)](#wait-long) |  |
+| [wait(long arg0, int arg1)](#wait-long-int) |  |
+### ReferencePointsSettings() {#ReferencePointsSettings}
+```
+public ReferencePointsSettings()
+```
+
+
+### RotationMarkerPosition {#RotationMarkerPosition}
+```
+public RotationPointPosition RotationMarkerPosition
+```
+
+
+テンプレート上の希望する回転マーカー位置。設定されていない場合は RotationPointPosition.TopRight1 が使用されます。マーカーは5番目の黒い長方形として描画されます。
+
+### equals(Object arg0) {#equals-java.lang.Object}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### hashCode() {#hashCode}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/japanese/java/com.aspose.omr/rotationpointposition/_index.md
+++ b/japanese/java/com.aspose.omr/rotationpointposition/_index.md
@@ -1,0 +1,290 @@
+---
+title: "RotationPointPosition"
+second_title: "Aspose.OMR for Java API リファレンス"
+description: 
+type: docs
+weight: 39
+url: /ja/java/com.aspose.omr/rotationpointposition/
+---
+
+**Inheritance:**
+java.lang.Object, java.lang.Enum
+```
+public enum RotationPointPosition extends Enum<RotationPointPosition>
+```
+## フィールド
+
+| フィールド | 説明 |
+| --- | --- |
+| [BottomLeft1](#BottomLeft1) |  |
+| [BottomLeft2](#BottomLeft2) |  |
+| [BottomRight1](#BottomRight1) |  |
+| [BottomRight2](#BottomRight2) |  |
+| [ID](#ID) |  |
+| [TopLeft1](#TopLeft1) |  |
+| [TopLeft2](#TopLeft2) |  |
+| [TopRight1](#TopRight1) |  |
+| [TopRight2](#TopRight2) |  |
+| [undefined](#undefined) |  |
+## メソッド
+
+| メソッド | 説明 |
+| --- | --- |
+| [<T>valueOf(Class<T> arg0, String arg1)](#-T-valueOf-java.lang.Class-T--java.lang.String) |  |
+| [compareTo(E arg0)](#compareTo-E) |  |
+| [equals(Object arg0)](#equals-java.lang.Object) |  |
+| [getClass()](#getClass) |  |
+| [getDeclaringClass()](#getDeclaringClass) |  |
+| [hashCode()](#hashCode) |  |
+| [name()](#name) |  |
+| [notify()](#notify) |  |
+| [notifyAll()](#notifyAll) |  |
+| [ordinal()](#ordinal) |  |
+| [toString()](#toString) |  |
+| [valueOf(String name)](#valueOf-java.lang.String) |  |
+| [values()](#values) |  |
+| [wait()](#wait) |  |
+| [wait(long arg0)](#wait-long) |  |
+| [wait(long arg0, int arg1)](#wait-long-int) |  |
+### BottomLeft1 {#BottomLeft1}
+```
+public static final RotationPointPosition BottomLeft1
+```
+
+
+### BottomLeft2 {#BottomLeft2}
+```
+public static final RotationPointPosition BottomLeft2
+```
+
+
+### BottomRight1 {#BottomRight1}
+```
+public static final RotationPointPosition BottomRight1
+```
+
+
+### BottomRight2 {#BottomRight2}
+```
+public static final RotationPointPosition BottomRight2
+```
+
+
+### ID {#ID}
+```
+public int ID
+```
+
+
+### TopLeft1 {#TopLeft1}
+```
+public static final RotationPointPosition TopLeft1
+```
+
+
+### TopLeft2 {#TopLeft2}
+```
+public static final RotationPointPosition TopLeft2
+```
+
+
+### TopRight1 {#TopRight1}
+```
+public static final RotationPointPosition TopRight1
+```
+
+
+### TopRight2 {#TopRight2}
+```
+public static final RotationPointPosition TopRight2
+```
+
+
+### undefined {#undefined}
+```
+public static final RotationPointPosition undefined
+```
+
+
+### <T>valueOf(Class<T> arg0, String arg1) {#-T-valueOf-java.lang.Class-T--java.lang.String}
+```
+public static T <T>valueOf(Class<T> arg0, String arg1)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | java.lang.Class<T> |  |
+| arg1 | java.lang.String |  |
+
+**Returns:**
+T
+### compareTo(E arg0) {#compareTo-E}
+```
+public final int compareTo(E arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | E |  |
+
+**Returns:**
+int
+### equals(Object arg0) {#equals-java.lang.Object}
+```
+public final boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getDeclaringClass() {#getDeclaringClass}
+```
+public final Class<E> getDeclaringClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<E>
+### hashCode() {#hashCode}
+```
+public final int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### name() {#name}
+```
+public final String name()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### notify() {#notify}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### ordinal() {#ordinal}
+```
+public final int ordinal()
+```
+
+
+
+
+**Returns:**
+int
+### toString() {#toString}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### valueOf(String name) {#valueOf-java.lang.String}
+```
+public static RotationPointPosition valueOf(String name)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 名前 | java.lang.String |  |
+
+**Returns:**
+[RotationPointPosition](../../com.aspose.omr/rotationpointposition/)
+### values() {#values}
+```
+public static RotationPointPosition[] values()
+```
+
+
+
+
+**Returns:**
+com.aspose.omr.RotationPointPosition[]
+### wait() {#wait}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/japanese/java/com.aspose.omr/templateprocessor/_index.md
+++ b/japanese/java/com.aspose.omr/templateprocessor/_index.md
@@ -1,0 +1,253 @@
+---
+title: "TemplateProcessor"
+second_title: "Aspose.OMR for Java API リファレンス"
+description: "テンプレートと画像を処理するクラス"
+type: docs
+weight: 30
+url: /ja/java/com.aspose.omr/templateprocessor/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public class TemplateProcessor
+```
+
+テンプレートと画像を処理するクラス。
+## メソッド
+
+| メソッド | 説明 |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object) |  |
+| [getClass()](#getClass) |  |
+| [hashCode()](#hashCode) |  |
+| [notify()](#notify) |  |
+| [notifyAll()](#notifyAll) |  |
+| [recalculate(RecognitionResult result)](#recalculate-com.aspose.omr.RecognitionResult) | 微調整されたパラメータを使用して認識結果を更新します。 |
+| [recalculate(RecognitionResult result, int recognitionThreshold)](#recalculate-com.aspose.omr.RecognitionResult-int) | 微調整されたパラメータを使用して認識結果を更新します。 |
+| [recognizeImage(BufferedImage bufferedImage)](#recognizeImage-java.awt.image.BufferedImage) | 画像を認識します |
+| [recognizeImage(BufferedImage bufferedImage, int recognitionThreshold)](#recognizeImage-java.awt.image.BufferedImage-int) | 画像を認識します |
+| [recognizeImage(InputStream inputStream)](#recognizeImage-java.io.InputStream) | 画像を認識します |
+| [recognizeImage(InputStream inputStream, int recognitionThreshold)](#recognizeImage-java.io.InputStream-int) | 画像を認識します |
+| [recognizeImage(String imagePath)](#recognizeImage-java.lang.String) | 画像を認識します |
+| [recognizeImage(String imagePath, int recognitionThreshold)](#recognizeImage-java.lang.String-int) | 画像を認識します |
+| [toString()](#toString) |  |
+| [wait()](#wait) |  |
+| [wait(long arg0)](#wait-long) |  |
+| [wait(long arg0, int arg1)](#wait-long-int) |  |
+### equals(Object arg0) {#equals-java.lang.Object}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### hashCode() {#hashCode}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### recalculate(RecognitionResult result) {#recalculate-com.aspose.omr.RecognitionResult}
+```
+public final void recalculate(RecognitionResult result)
+```
+
+
+微調整されたパラメータを使用して認識結果を更新します。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| result | [RecognitionResult](../../com.aspose.omr/recognitionresult/) | 更新する認識結果です。 |
+
+### recalculate(RecognitionResult result, int recognitionThreshold) {#recalculate-com.aspose.omr.RecognitionResult-int}
+```
+public final void recalculate(RecognitionResult result, int recognitionThreshold)
+```
+
+
+微調整されたパラメータを使用して認識結果を更新します。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| result | [RecognitionResult](../../com.aspose.omr/recognitionresult/) | 更新する認識結果です。 |
+| recognitionThreshold | int | （オプション）認識しきい値（0〜100）の範囲です。しきい値を超えて入力された要素のみが入力済みとしてカウントされます。 |
+
+### recognizeImage(BufferedImage bufferedImage) {#recognizeImage-java.awt.image.BufferedImage}
+```
+public final RecognitionResult recognizeImage(BufferedImage bufferedImage)
+```
+
+
+画像を認識します
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| bufferedImage | java.awt.image.BufferedImage | 認識対象の画像 |
+
+**Returns:**
+[RecognitionResult](../../com.aspose.omr/recognitionresult/) - The recognition result
+### recognizeImage(BufferedImage bufferedImage, int recognitionThreshold) {#recognizeImage-java.awt.image.BufferedImage-int}
+```
+public final RecognitionResult recognizeImage(BufferedImage bufferedImage, int recognitionThreshold)
+```
+
+
+画像を認識します
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| bufferedImage | java.awt.image.BufferedImage | 認識対象の画像 |
+| recognitionThreshold | int | （オプション）認識しきい値（0〜100）の範囲です。しきい値を超えて入力された要素のみが入力済みとしてカウントされます。 |
+
+**Returns:**
+[RecognitionResult](../../com.aspose.omr/recognitionresult/) - The recognition result
+### recognizeImage(InputStream inputStream) {#recognizeImage-java.io.InputStream}
+```
+public final RecognitionResult recognizeImage(InputStream inputStream)
+```
+
+
+画像を認識します
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| inputStream | java.io.InputStream | 画像のストリーム |
+
+**Returns:**
+[RecognitionResult](../../com.aspose.omr/recognitionresult/) - The recognition result
+### recognizeImage(InputStream inputStream, int recognitionThreshold) {#recognizeImage-java.io.InputStream-int}
+```
+public final RecognitionResult recognizeImage(InputStream inputStream, int recognitionThreshold)
+```
+
+
+画像を認識します
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| inputStream | java.io.InputStream | 画像のストリーム |
+| recognitionThreshold | int | （オプション）認識しきい値（0〜100）の範囲です。しきい値を超えて入力された要素のみが入力済みとしてカウントされます。 |
+
+**Returns:**
+[RecognitionResult](../../com.aspose.omr/recognitionresult/) - The recognition result
+### recognizeImage(String imagePath) {#recognizeImage-java.lang.String}
+```
+public final RecognitionResult recognizeImage(String imagePath)
+```
+
+
+画像を認識します
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| imagePath | java.lang.String | 認識対象画像へのパス |
+
+**Returns:**
+[RecognitionResult](../../com.aspose.omr/recognitionresult/) - The recognition result
+### recognizeImage(String imagePath, int recognitionThreshold) {#recognizeImage-java.lang.String-int}
+```
+public final RecognitionResult recognizeImage(String imagePath, int recognitionThreshold)
+```
+
+
+画像を認識します
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| imagePath | java.lang.String | 認識対象画像へのパス |
+| recognitionThreshold | int | （オプション）認識しきい値（0〜100）の範囲です。しきい値を超えて入力された要素のみが入力済みとしてカウントされます。 |
+
+**Returns:**
+[RecognitionResult](../../com.aspose.omr/recognitionresult/) - The recognition result
+### toString() {#toString}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+


### PR DESCRIPTION
Automated translation of the JAVA API Reference to **Japanese** (`ja`) generated by RDA.

- Pages translated: 32/32
- Errors: 0
- Source: `english/java`
- Output: `japanese/java`

🤖 Generated by RDA